### PR TITLE
Fixing Setting Value Retrieval by Scope

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -158,8 +158,9 @@ class Api extends AbstractHelper
 
     public function getSettingsVal($val)
     {
-        $scope = ($this->request->getParam('store')) ?: $this->request->getParam('website');
-        return $this->_scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $scope);
+        $scope = ($s = $this->request->getParam('store')) ?: $w = $this->request->getParam('website');
+        $scope_label = $s? ScopeInterface::SCOPE_STORE : ScopeInterface::SCOPE_WEBSITE;
+        return $this->_scopeConfig->getValue($val, $scope_label, $scope);
     }
 
     /* Content */

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -2,10 +2,10 @@
 
 namespace Sailthru\MageSail\Helper;
 
+use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\ScopeInterface;
 use Sailthru\MageSail\Cookie\Hid;
 use Magento\Framework\App\Helper\AbstractHelper;
-use Magento\Framework\App\MutableScopeConfig;
 
 class Api extends AbstractHelper
 {
@@ -23,7 +23,7 @@ class Api extends AbstractHelper
     const XML_API_KEY                  = "magesail_config/service/api_key";
     const XML_API_SECRET               = "magesail_config/service/secret_key";
     const API_SUCCESS_MESSAGE          = "Successfully Validated!";
-    
+
     // Settings lists
     const XML_ONREGISTER_LIST_ENABLED  = "magesail_lists/lists/enable_signup_list";
     const XML_ONREGISTER_LIST_VALUE    = "magesail_lists/lists/signup_list";
@@ -79,10 +79,19 @@ class Api extends AbstractHelper
         'quantity_and_stock_status',
         'sku'
     ];
-    
-    public function __construct(MutableScopeConfig $scopeConfig, Hid $hid)
-    {
-        $this->_scopeConfig = $scopeConfig;
+
+    /**
+     * @var \Magento\Framework\App\Request\Http
+     */
+    protected $request;
+
+    public function __construct(
+        Context $context,
+        Hid $hid
+    ) {
+        parent::__construct($context);
+        $this->_scopeConfig = $context->getScopeConfig();
+        $this->request = $context->getRequest();
         $this->hid = $hid;
         $this->_apiKey = $this->getApiKey();
         $this->_apiSecret = $this->getApiSecret();
@@ -149,7 +158,8 @@ class Api extends AbstractHelper
 
     public function getSettingsVal($val)
     {
-        return $this->_scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE);
+        $scope = ($this->request->getParam('store')) ?: $this->request->getParam('website');
+        return $this->_scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $scope);
     }
 
     /* Content */

--- a/Plugin/ProductIntercept.php
+++ b/Plugin/ProductIntercept.php
@@ -7,6 +7,7 @@ use Magento\Catalog\Helper\Image as ImageHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type\Simple;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as Configurable;
+use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Filesystem;
 use Magento\Store\Model\StoreManagerInterface;
 use Sailthru\MageSail\Helper\Api;
@@ -52,13 +53,16 @@ class ProductIntercept
         StoreManagerInterface $storeManager,
         ProductHelper $productHelper,
         ImageHelper $imageHelper,
-        Configurable $cpModel
+        Configurable $cpModel,
+        Context $context
     ) {
         $this->sailthru = $sailthru;
         $this->_storeManager = $storeManager;
         $this->productHelper = $productHelper;
         $this->imageHelper = $imageHelper;
         $this->cpModel = $cpModel;
+        $this->context = $context;
+        $this->request = $context->getRequest();
     }
 
     public function afterAfterSave(Product $productModel, $productResult)
@@ -103,7 +107,7 @@ class ProductIntercept
 
         // scope fix for intercept launched from backoffice, which causes admin URLs for products
         $storeScopes = $product->getStoreIds();
-        $storeId = $storeScopes ? $storeScopes[0] : $product->getStoreId();
+        $storeId = $this->request->getParam('store') ?: $storeScopes[0];
         if ($storeId) {
             $product->setStoreId($storeId);
         }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,9 +14,9 @@
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="service" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="service" translate="label" type="text" sortOrder="1"  showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Sailthru API Setup</label>
-                <field id="api_key" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="api_key" translate="label" type="text" sortOrder="1"  showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>API Key</label>
                 </field>                
                 <field id="secret_key" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -30,18 +30,18 @@
             </group>
         </section>
 
-        <section id="magesail_content" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
+        <section id="magesail_content"  showInWebsite="1" showInStore="1" sortOrder="1">
             <label>Content</label>
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
-            <group id="intercept" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
+            <group id="intercept" translate="label" type="text"  showInWebsite="1" showInStore="1" sortOrder="0">
                 <label>Sailthru Product Updates</label>
-                <field id="enable_intercept" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
+                <field id="enable_intercept" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="0">
                     <label>Send products to Sailthru on product update</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>This allows us to keep your content library in-sync with Magento.</comment>
                 </field>
-                <field id="send_master" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
+                <field id="send_master" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="1">
                     <label>Send Configurable/Master Products to Sailthru</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Should Configurable products (masters) be sent to Sailthru</comment>
@@ -49,7 +49,7 @@
                         <field id="*/*/enable_intercept">1</field>
                     </depends>
                 </field>
-                <field id="send_variants" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="2">
+                <field id="send_variants" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="2">
                     <label>Send Variant Products to Sailthru</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Should variant products be sent to Sailthru. NOTE: If variants aren't visible individually, must enable URL-fragmenting in Sailthru.</comment>
@@ -58,17 +58,17 @@
                     </depends>
                 </field>
             </group>
-            <group id="tags" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
+            <group id="tags" translate="label" type="text"  showInWebsite="1" showInStore="1" sortOrder="1">
                 <label>Product Tags</label>
-                <field id="use_seo" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
+                <field id="use_seo" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="1">
                     <label>Get tags from SEO keywords</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="use_attributes" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="3">
+                <field id="use_attributes" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="3">
                     <label>Get tags from from product attributes</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="use_categories" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="2">
+                <field id="use_categories" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="2">
                     <label>Get tags from categories</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
@@ -76,19 +76,19 @@
 
         </section>
 
-        <section id="magesail_lists" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="magesail_lists" translate="label" sortOrder="1"  showInWebsite="1" showInStore="1">
             <tab>sailthru</tab>
             <label>Lists</label>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="lists" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="lists" translate="label" type="text" sortOrder="2"  showInWebsite="1" showInStore="1">
                 <label>Lists</label>
-                <field id="enable_signup_list" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_signup_list" translate="label" type="select"  showInWebsite="1" showInStore="1">
                     <label>Add new registering customers to Sailthru list</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>Upon registration, set users to be added to a Sailthru list of your choice.</comment>
                 </field>
-                 <field id="signup_list" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                 <field id="signup_list" translate="label" type="select" sortOrder="1"  showInWebsite="1" showInStore="1">
                     <label>Customer Sign-Up Lists</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrulists</source_model>
                     <tooltip><![CDATA[New a new list? Check my.sailthru.com to create it!]]></tooltip>
@@ -97,12 +97,12 @@
                         <field id="*/*/enable_signup_list">1</field>
                     </depends>
                 </field>
-                <field id="enable_newsletter" translate="label comment" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_newsletter" translate="label comment" type="select" sortOrder="2"  showInWebsite="1" showInStore="1">
                     <label>Override Default Magento Newsletter Subscribe</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>Override Magento's default Newsletter system and add users instead to a Sailthru List</comment>
                 </field>
-               <field id="newsletter_list" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+               <field id="newsletter_list" translate="label" type="select" sortOrder="3"  showInWebsite="1" showInStore="1">
                     <label>Newsletter Lists</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrulists</source_model>
                     <tooltip><![CDATA[New a new list? Check my.sailthru.com to create it!]]></tooltip>
@@ -113,20 +113,20 @@
             </group>
         </section>
 
-        <section id="magesail_send" translate="label" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+        <section id="magesail_send" translate="label" sortOrder="2"  showInWebsite="1" showInStore="1">
             <label>Transactionals</label>
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="transactionals" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="transactionals" translate="label" type="text" sortOrder="2"  showInWebsite="1" showInStore="1">
                 <label>General Transactionals</label>
-                <field id="send_through_sailthru" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
+                <field id="send_through_sailthru" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="0">
                     <label>Send all transactionals through Sailthru</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <tooltip>Allows you to send all Magento emails through Sailthru, and override templates for various Magento events.</tooltip>
                     <comment>NOTE: Will create generic Sailthru templates that will accept Magento templates for transactionals not specifically overriden.</comment>
                 </field>
-                <field id="from_sender" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="from_sender" translate="label" type="select"  showInWebsite="1" showInStore="1">
                     <label>From Email</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Verifiedemails</source_model>
                     <comment>All transactionals sent using Magento templates must be sent from a Sailthru-verified email.</comment>
@@ -135,14 +135,14 @@
                         <field id="*/*/send_through_sailthru">1</field>
                     </depends>
                 </field>
-                <field id="purchase_enabled" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="3">
+                <field id="purchase_enabled" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="3">
                     <label>Override Magento Purchase Confirmation</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <depends>
                         <field id="*/*/send_through_sailthru">1</field>
                     </depends>
                 </field>
-                <field id="purchase_template" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="4">
+                <field id="purchase_template" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="4">
                     <label>Purchase Confirmation Template</label>
                     <depends>
                         <field id="*/*/purchase_enabled">1</field>
@@ -152,20 +152,20 @@
                 </field>
             </group>
 
-            <group id="abandoned_cart" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="abandoned_cart" translate="label" type="text" sortOrder="1"  showInWebsite="1" showInStore="1">
                 <label>Sailthru Abandoned Cart</label>
-                <field id="enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled" translate="label" type="select" sortOrder="1"  showInWebsite="1" showInStore="1">
                     <label>Enable Abandoned Cart</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                 </field>                
-                <field id="template" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="template" translate="label" type="select" sortOrder="2"  showInWebsite="1" showInStore="1">
                     <label>Abandoned Cart Template</label>
                     <depends>
                         <field id="*/*/enabled">1</field>
                     </depends>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrutemplates</source_model>
                 </field>
-                <field id="delay_time" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="delay_time" translate="label" type="text" sortOrder="3"  showInWebsite="1" showInStore="1">
                     <label>Abandoned Cart Send Time</label>
                     <tooltip>e.g. 5 minutes, 1 hour, 1 day</tooltip>
                     <comment>Amount of time after updating a non-empty cart that Sailthru should send the customer an email</comment>
@@ -173,7 +173,7 @@
                         <field id="*/*/enabled">1</field>
                     </depends>
                 </field>
-                <field id="anonymous_carts" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="anonymous_carts" translate="label" type="select" sortOrder="4"  showInWebsite="1" showInStore="1">
                     <label>Send Abandoned Carts to Guest Users with HID</label>
                     <comment>Enabling will allow you to send Abandoned Carts to customers who aren't currently signed-in, but have a sailthru_hid cookie for your site.</comment>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="service" translate="label" type="text" sortOrder="1"  showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="service" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Sailthru API Setup</label>
                 <field id="api_key" translate="label" type="text" sortOrder="1"  showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>API Key</label>


### PR DESCRIPTION
This PR builds on PR #12 by @alexpoletaev and adds the context-switching for config retrieval between store and site, as well as removing default values for all MageSail values except API Key and Secret.