### PR TITLE
Fix email address corruption

### DIFF
--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -83,8 +83,11 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
 
     public function cleanEmail($str)
     {
-        $startPart = strpos($str, '<') + 1;
-        $email = substr($str, $startPart);
+        $startPart = strpos($str, '<');
+        if ($startPart === false) {
+            return $str;
+        }
+        $email = substr($str, $startPart + 1);
         $email = substr($email, 0, -1);
         return $email;
     }


### PR DESCRIPTION
This fixes corruption of an email address when it's in a basic format `user@example.com` instead of the extended format `User Name <user@example.com>`.