### PR TITLE
Client Error Handling Fix + JS Documentation Fix

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -127,11 +127,13 @@ class Api extends AbstractHelper
 
     public function apiValidate()
     {
-        $result = $this->client->getSettings();
-        if (!array_key_exists("error", $result)) {
-            return [1, self::API_SUCCESS_MESSAGE];
-        } else {
-            return [0, $result["errormsg"]];
+        try {
+            $result = $this->client->getSettings();
+            if (!array_key_exists("error", $result)) {
+                return [1, self::API_SUCCESS_MESSAGE];
+            }
+        } catch (\Exception $e) {
+            return [0, $e->getMessage()];
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,25 @@
 2. Enable the module
     `bin/magento module:enable Sailthru_Magesail`
 
-3. Go to Magento Admin > Stores > Configuration > Sailthru to configure. Visit the [Sailthru Documentation Site](https://getstarted.sailthru.com/integrations/magento/magento-2-extension/) for setup documentation.
+3. Upgrade the database
+	`bin/magento setup:upgrade`
+   *(Depending on Magento mode, you may need to run `magento setup:di:compile`)*
+
+4. Go to Magento Admin > Stores > Configuration > Sailthru to configure. Visit the [Sailthru Documentation Site](https://getstarted.sailthru.com/integrations/magento/magento-2-extension/) for setup documentation.
 
 *__Note__: If sync'ing variant products with no visible individual URL, you should enable "Preserve Fragments" in Sailthru [here][2].*
 
-## SPM Setup
-The Sailthru MageSail module comes ready to use Sailthru's new PersonalizeJs javascript.
- - To add page-tracking and gather onsite data like pageviews and clicks, set "Site Domain" at https://my.sailthru.com/settings/domains.
- - To use Site Personalization Manager, please contact Sailthru.
+## Javascript Setup
+The Sailthru MageSail module comes ready to use Sailthru's new PersonalizeJs javascript. To add page-tracking and gather onsite data like pageviews and clicks: 
+
+1. Set your "Site Domain" [here][3].
+2. Add your Customer ID (found [here][4]) to vendor/sailthru/sailthru-magento2-extension/view/frontend/web/spm.js 
+
+**Please contact Sailthru to learn more about and enable Site Personalization Manager.**
 
 
 [1]: https://getstarted.sailthru.com/integrations/overview/
 [2]: https://my.sailthru.com/settings/spider
+[3]: https://my.sailthru.com/settings/domains
+[4]: https://my.sailthru.com/settings/api_postbacks
+

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "magento/module-catalog": "^101.*",
     "magento/module-customer": "^100.1.*"
   },
-  "version": "1.0.2",
+  "version": "1.0.3-dev",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type":"magento2-module",
   "require": {
     "php": "~5.6.0|~7.0.0",
-    "sailthru/sailthru-php5-client": "^1.2"
+    "sailthru/sailthru-php5-client": "1.2.2"
   },
   "suggest": {
     "magento/module-newsletter": "^101.*",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -30,18 +30,18 @@
             </group>
         </section>
 
-        <section id="magesail_content"  showInWebsite="1" showInStore="1" sortOrder="1">
+        <section id="magesail_content" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
             <label>Content</label>
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
-            <group id="intercept" translate="label" type="text"  showInWebsite="1" showInStore="1" sortOrder="0">
+            <group id="intercept" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
                 <label>Sailthru Product Updates</label>
-                <field id="enable_intercept" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="0">
+                <field id="enable_intercept" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
                     <label>Send products to Sailthru on product update</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>This allows us to keep your content library in-sync with Magento.</comment>
                 </field>
-                <field id="send_master" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="1">
+                <field id="send_master" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
                     <label>Send Configurable/Master Products to Sailthru</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Should Configurable products (masters) be sent to Sailthru</comment>
@@ -49,7 +49,7 @@
                         <field id="*/*/enable_intercept">1</field>
                     </depends>
                 </field>
-                <field id="send_variants" translate="label comment" type="select"  showInWebsite="1" showInStore="1" sortOrder="2">
+                <field id="send_variants" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="2">
                     <label>Send Variant Products to Sailthru</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Should variant products be sent to Sailthru. NOTE: If variants aren't visible individually, must enable URL-fragmenting in Sailthru.</comment>
@@ -58,17 +58,17 @@
                     </depends>
                 </field>
             </group>
-            <group id="tags" translate="label" type="text"  showInWebsite="1" showInStore="1" sortOrder="1">
+            <group id="tags" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
                 <label>Product Tags</label>
-                <field id="use_seo" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="1">
+                <field id="use_seo" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
                     <label>Get tags from SEO keywords</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="use_attributes" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="3">
+                <field id="use_attributes" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="3">
                     <label>Get tags from from product attributes</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="use_categories" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="2">
+                <field id="use_categories" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="2">
                     <label>Get tags from categories</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
@@ -76,19 +76,19 @@
 
         </section>
 
-        <section id="magesail_lists" translate="label" sortOrder="1"  showInWebsite="1" showInStore="1">
+        <section id="magesail_lists" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
             <tab>sailthru</tab>
             <label>Lists</label>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="lists" translate="label" type="text" sortOrder="2"  showInWebsite="1" showInStore="1">
+            <group id="lists" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Lists</label>
-                <field id="enable_signup_list" translate="label" type="select"  showInWebsite="1" showInStore="1">
+                <field id="enable_signup_list" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Add new registering customers to Sailthru list</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>Upon registration, set users to be added to a Sailthru list of your choice.</comment>
                 </field>
-                 <field id="signup_list" translate="label" type="select" sortOrder="1"  showInWebsite="1" showInStore="1">
+                 <field id="signup_list" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Customer Sign-Up Lists</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrulists</source_model>
                     <tooltip><![CDATA[New a new list? Check my.sailthru.com to create it!]]></tooltip>
@@ -97,12 +97,12 @@
                         <field id="*/*/enable_signup_list">1</field>
                     </depends>
                 </field>
-                <field id="enable_newsletter" translate="label comment" type="select" sortOrder="2"  showInWebsite="1" showInStore="1">
+                <field id="enable_newsletter" translate="label comment" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Override Default Magento Newsletter Subscribe</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <comment>Override Magento's default Newsletter system and add users instead to a Sailthru List</comment>
                 </field>
-               <field id="newsletter_list" translate="label" type="select" sortOrder="3"  showInWebsite="1" showInStore="1">
+               <field id="newsletter_list" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Newsletter Lists</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrulists</source_model>
                     <tooltip><![CDATA[New a new list? Check my.sailthru.com to create it!]]></tooltip>
@@ -113,20 +113,20 @@
             </group>
         </section>
 
-        <section id="magesail_send" translate="label" sortOrder="2"  showInWebsite="1" showInStore="1">
+        <section id="magesail_send" translate="label" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Transactionals</label>
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
 
-            <group id="transactionals" translate="label" type="text" sortOrder="2"  showInWebsite="1" showInStore="1">
+            <group id="transactionals" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Transactionals</label>
-                <field id="send_through_sailthru" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="0">
+                <field id="send_through_sailthru" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="0">
                     <label>Send all transactionals through Sailthru</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <tooltip>Allows you to send all Magento emails through Sailthru, and override templates for various Magento events.</tooltip>
                     <comment>NOTE: Will create generic Sailthru templates that will accept Magento templates for transactionals not specifically overriden.</comment>
                 </field>
-                <field id="from_sender" translate="label" type="select"  showInWebsite="1" showInStore="1">
+                <field id="from_sender" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>From Email</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Verifiedemails</source_model>
                     <comment>All transactionals sent using Magento templates must be sent from a Sailthru-verified email.</comment>
@@ -135,14 +135,14 @@
                         <field id="*/*/send_through_sailthru">1</field>
                     </depends>
                 </field>
-                <field id="purchase_enabled" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="3">
+                <field id="purchase_enabled" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="3">
                     <label>Override Magento Purchase Confirmation</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                     <depends>
                         <field id="*/*/send_through_sailthru">1</field>
                     </depends>
                 </field>
-                <field id="purchase_template" translate="label" type="select"  showInWebsite="1" showInStore="1" sortOrder="4">
+                <field id="purchase_template" translate="label" type="select"  showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="4">
                     <label>Purchase Confirmation Template</label>
                     <depends>
                         <field id="*/*/purchase_enabled">1</field>
@@ -152,20 +152,20 @@
                 </field>
             </group>
 
-            <group id="abandoned_cart" translate="label" type="text" sortOrder="1"  showInWebsite="1" showInStore="1">
+            <group id="abandoned_cart" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Sailthru Abandoned Cart</label>
-                <field id="enabled" translate="label" type="select" sortOrder="1"  showInWebsite="1" showInStore="1">
+                <field id="enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Abandoned Cart</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>
                 </field>                
-                <field id="template" translate="label" type="select" sortOrder="2"  showInWebsite="1" showInStore="1">
+                <field id="template" translate="label" type="select" sortOrder="2"  showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Abandoned Cart Template</label>
                     <depends>
                         <field id="*/*/enabled">1</field>
                     </depends>
                     <source_model>Sailthru\MageSail\Model\Config\Source\Sailthrutemplates</source_model>
                 </field>
-                <field id="delay_time" translate="label" type="text" sortOrder="3"  showInWebsite="1" showInStore="1">
+                <field id="delay_time" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Abandoned Cart Send Time</label>
                     <tooltip>e.g. 5 minutes, 1 hour, 1 day</tooltip>
                     <comment>Amount of time after updating a non-empty cart that Sailthru should send the customer an email</comment>
@@ -173,7 +173,7 @@
                         <field id="*/*/enabled">1</field>
                     </depends>
                 </field>
-                <field id="anonymous_carts" translate="label" type="select" sortOrder="4"  showInWebsite="1" showInStore="1">
+                <field id="anonymous_carts" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Send Abandoned Carts to Guest Users with HID</label>
                     <comment>Enabling will allow you to send Abandoned Carts to customers who aren't currently signed-in, but have a sailthru_hid cookie for your site.</comment>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnabledisable</source_model>

--- a/view/adminhtml/templates/system/validateapi.phtml
+++ b/view/adminhtml/templates/system/validateapi.phtml
@@ -1,10 +1,3 @@
-<!-- <div class="pp-buttons-container">
-    <button id="<?php echo $block->getHtmlId() ?>" onclick="return false;">
-        <span><?php echo $block->escapeHtml($block->getButtonLabel()) ?></span>
-    </button>
-</div> -->
-<!-- <input id="<?php echo $block->getHtmlId() ?>" name="<?php echo $block->getName(); ?>" data-ui-id="form-element-<? echo $block->getName() . ($suffix ?: '') ?>" value="<?php echo $block->getSuccess() ?>" class=" input-text admin__control-text" type="text">
- -->
 <div class="<?php echo $block->getClass() ?>">
 	<h1><?php echo $block->getStatus() ?></h1>
 	<h2><?php echo $block->getMessage() ?></h2>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,17 +1,6 @@
-// var config = {
-//     paths: {
-//     "Sailthru": "https://ak.sail-horizon.com/onsite/personalize.v0.0.4.min",
-//     },
-//     waitSeconds: 300,
-//     shim: {
-//         Sailthru: {
-//             exports: 'Sailthru'
-//         },
-//     }
-// };
 var config = {
     paths: {
-    	"Sailthru": "http://127.0.0.1:8080/spm.v1.min",
+    	"Sailthru": "https://ak.sail-horizon.com/spm/spm.v1.min",
     },
     waitSeconds: 300,
     shim: {

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,6 +1,17 @@
+// var config = {
+//     paths: {
+//     "Sailthru": "https://ak.sail-horizon.com/onsite/personalize.v0.0.4.min",
+//     },
+//     waitSeconds: 300,
+//     shim: {
+//         Sailthru: {
+//             exports: 'Sailthru'
+//         },
+//     }
+// };
 var config = {
     paths: {
-    "Sailthru": "https://ak.sail-horizon.com/onsite/personalize.v0.0.4.min",
+    	"Sailthru": "http://127.0.0.1:8080/spm.v1.min",
     },
     waitSeconds: 300,
     shim: {

--- a/view/frontend/web/spm.js
+++ b/view/frontend/web/spm.js
@@ -1,4 +1,10 @@
+// require(["Sailthru"], function (Sailthru) {
+//     console.log(Sailthru);
+//     console.log('Want to use SPM with JSON? Configure it here!');
+// }); 
 require(["Sailthru"], function (Sailthru) {
     console.log(Sailthru);
-    console.log('Want to use SPM with JSON? Configure it here!');
-}); 
+    console.log('Want to use SPM with JSON?! WOO');
+    var client_id = '45124590f1851dcdcf7ac2e38d793cd2';
+    Sailthru.init({ customerId: client_id});
+});

--- a/view/frontend/web/spm.js
+++ b/view/frontend/web/spm.js
@@ -1,10 +1,5 @@
-// require(["Sailthru"], function (Sailthru) {
-//     console.log(Sailthru);
-//     console.log('Want to use SPM with JSON? Configure it here!');
-// }); 
 require(["Sailthru"], function (Sailthru) {
-    console.log(Sailthru);
-    console.log('Want to use SPM with JSON?! WOO');
-    var client_id = '45124590f1851dcdcf7ac2e38d793cd2';
+	console.log("Edit this file to use SPM onsite!");
+    var client_id = '<ENTER_CLIENT_ID_HERE>';
     Sailthru.init({ customerId: client_id});
 });


### PR DESCRIPTION
The Sailthru Client Library for PHP was updated to throw exceptions on bad API responses. This update specifies the version 1.2.2, which precedes the error-handling update and starts building try/catch logic for the extension.

Also updated README for better JS-usage instructions.