### PR TITLE
IN-562/IN-653 Improve/Isolate Logger

### DIFF
--- a/Block/System/Config/Button/Check.php
+++ b/Block/System/Config/Button/Check.php
@@ -3,16 +3,20 @@
 namespace Sailthru\MageSail\Block\System\Config\Button;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Sailthru\MageSail\Helper\ClientManager;
 
 class Check extends \Magento\Config\Block\System\Config\Form\Field
 {
 
+    /** @var ClientManager  */
+    private $clientManager;
+
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
-        \Sailthru\MageSail\Helper\Api $sailthru,
+        ClientManager $clientManager,
         array $data = []
     ) {
-        $this->_sailthru = $sailthru;
+        $this->clientManager = $clientManager;
         parent::__construct($context, $data);
     }
 
@@ -57,7 +61,7 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
     {
         $originalData = $element->getOriginalData();
         $buttonLabel = !empty($originalData['button_label']) ? $originalData['button_label'] : 'Validate Credentials';
-        $api_validate = $this->_sailthru->apiValidate();
+        $api_validate = $this->clientManager->apiValidate();
         if ($api_validate[0] == 1) {
             $data = [
                 'class' => 'sail_success',

--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -6,15 +6,20 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManager;
 use Magento\Framework\App\Helper\AbstractHelper as MageAbstractHelper;
+use Sailthru\MageSail\Logger;
 
 class AbstractHelper extends MageAbstractHelper
 {
     /** @var StoreManager  */
     protected $storeManager;
 
-    public function __construct(Context $context, StoreManager $storeManager) {
+    /** @var Logger  */
+    protected $logger;
+
+    public function __construct(Context $context, StoreManager $storeManager, Logger $logger) {
         parent::__construct($context);
         $this->storeManager = $storeManager;
+        $this->logger = $logger;
     }
 
     public function getSettingsVal($val)

--- a/Helper/ClientManager.php
+++ b/Helper/ClientManager.php
@@ -4,16 +4,11 @@ namespace Sailthru\MageSail\Helper;
 
 use Magento\Store\Model\StoreManager;
 use Magento\Framework\App\Helper\Context;
+use Sailthru\MageSail\Logger;
 use Sailthru\MageSail\MageClient;
 
 class ClientManager extends AbstractHelper
 {
-
-    /** @var  string */
-    protected $_apiKey;
-
-    /** @var string */
-    protected $_apiSecret;
 
     /** @var  MageClient */
     protected $client;
@@ -24,35 +19,25 @@ class ClientManager extends AbstractHelper
 
     public function __construct(
         Context $context,
-        StoreManager $storeManager
+        StoreManager $storeManager,
+        Logger $logger
     ) {
-        parent::__construct($context, $storeManager);
-        $this->_apiKey = $this->getApiKey();
-        $this->_apiSecret = $this->getApiSecret();
+        parent::__construct($context, $storeManager, $logger);
         $this->initClient();
-    }
-
-    private function getApiKey()
-    {
-        return $this->getSettingsVal(self::XML_API_KEY);
-    }
-
-    private function getApiSecret()
-    {
-        return $this->getSettingsVal(self::XML_API_SECRET);
     }
 
     public function initClient()
     {
-        $this->client = new MageClient(
-            $this->_apiKey,
-            $this->_apiSecret,
-            '/var/log/sailthru.log'
-        );
+        $apiKey = $this->getSettingsVal(self::XML_API_KEY);
+        $apiSecret = $this->getSettingsVal(self::XML_API_SECRET);
+        $this->client = new MageClient($apiKey, $apiSecret, $this->logger, $this->storeManager);
     }
 
-    public function getClient()
+    public function getClient($update=false)
     {
+        if ($update) {
+            $this->initClient();
+        }
         return $this->client;
     }
 

--- a/Logger.php
+++ b/Logger.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sailthru\MageSail;
+
+use Magento\Store\Model\StoreManager;
+use Zend\Log\Logger as ZendLogger;
+use Zend\Log\Writer\Stream;
+
+class Logger extends ZendLogger
+{
+
+    const SAILTHRU_PATH = '/var/log/sailthru.log';
+
+    /** @var StoreManager  */
+    private $storeManager;
+
+    public function __construct(ZendLogger $logger, StoreManager $storeManager)
+    {
+        parent::__construct();
+        $streamWriter = new Stream(BP . self::SAILTHRU_PATH);
+        $this->addWriter($streamWriter);
+        $this->storeManager = $storeManager;
+    }
+
+    public function logApiRequest($eventType, $httpType, $method, $action, $payload)
+    {
+        $store = $this->storeManager->getStore();
+        $this->info([
+            'action'            => "{$method} /{$action}",
+            'event_type'        => $eventType,
+            'store_id'          => "{$store->getId()} | {$store->getName()}",
+            'http_request_type' => $httpType, // http request type (with or without curl)
+            'request'           => $payload
+        ]);
+    }
+
+
+}


### PR DESCRIPTION
This separates the logger from the MageClient class, though leaves the method for compatibility's sake (and adds a deprecated warning).

Also adds:

- Improved API logging, including log levels! INFO for API requests and response, ERROR for API errors
- Makes MageClient slightly more dynamic