### PR TITLE
CLI Product Import Tool + Content API Improvements

### DIFF
--- a/Console/Command/Import.php
+++ b/Console/Command/Import.php
@@ -4,6 +4,8 @@
 namespace Sailthru\MageSail\Console\Command;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Block\Product\AbstractProduct;
+use Magento\Catalog\Helper\Image;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
@@ -80,6 +82,8 @@ class Import extends Command
     ) {
         $storeId = $input->getArgument(self::STORE_ARGUMENT);
         $this->productCollection->setStoreId($storeId);
+        $this->state->setAreaCode(Area::AREA_FRONTEND);
+
         $this->productCollection
             ->addAttributeToSelect("*")
             ->addStoreFilter($storeId)
@@ -95,8 +99,6 @@ class Import extends Command
         $storeName = $this->storeManager->getStore($storeId)->getName();
         $output->writeln("Checking {$this->productCollection->getSize()} products to import for Store #$storeId $storeName");
 
-        $this->state->setAreaCode(Area::AREA_FRONTEND);
-        $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND);
         $sailClient = $this->clientManager->getClient(true, $storeId);
         $sailClient->_eventType = $this::EVENT_NAME;
 
@@ -142,7 +144,6 @@ class Import extends Command
 
         $endTime = microtime(true);
         $time = $endTime - $startTime;
-        $this->emulation->stopEnvironmentEmulation();
 
         if ($skippedProducts) {
             $productString = $this->printableProducts($skippedProducts);

--- a/Console/Command/Import.php
+++ b/Console/Command/Import.php
@@ -1,0 +1,167 @@
+<?php
+
+
+namespace Sailthru\MageSail\Console\Command;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Store\Model\App\Emulation;
+use Magento\Store\Model\StoreManagerInterface;
+use Sailthru\MageSail\Helper\ClientManager;
+use Sailthru\MageSail\Plugin\ProductIntercept;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Import extends Command
+{
+
+    const STORE_ARGUMENT = "<storeID>";
+
+    const EVENT_NAME = "cli_product_sync";
+
+    /** @var ClientManager  */
+    protected $clientManager;
+
+    /** @var ProductIntercept  */
+    protected $productIntercept;
+
+    /** @var Collection  */
+    protected $productCollection;
+
+    /** @var Emulation  */
+    protected $emulation;
+
+    /** @var State  */
+    private $state;
+
+    /** @var StoreManagerInterface  */
+    private $storeManager;
+
+    public function __construct(
+        ClientManager $clientManager,
+        ProductIntercept $productIntercept,
+        Collection $productCollection,
+        Emulation $emulation,
+        State $state,
+        StoreManagerInterface $storeManager
+    ) {
+        parent::__construct();
+        $this->clientManager = $clientManager;
+        $this->productIntercept = $productIntercept;
+        $this->productCollection = $productCollection;
+        $this->emulation = $emulation;
+        $this->state = $state;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        $storeId = $input->getArgument(self::STORE_ARGUMENT);
+        $this->productCollection->setStoreId($storeId);
+        $this->productCollection
+            ->addAttributeToSelect("*")
+            ->addStoreFilter($storeId)
+            ->setPageSize(75)
+            ->load();
+
+        $storeName = $this->storeManager->getStore($storeId)->getName();
+        $output->writeln("Checking {$this->productCollection->getSize()} products to import for Store #$storeId $storeName");
+
+        $this->state->setAreaCode(Area::AREA_FRONTEND);
+        $sailClient = $this->clientManager->getClient(true, $storeId);
+        $sailClient->_eventType = $this::EVENT_NAME;
+
+        $actionId = time();
+        $checkedProducts = 0;
+        $syncedProducts = 0;
+        $skippedProducts = [];
+        $failedProducts = [];
+        $page = 1;
+        $startTime = microtime(true);
+
+        do {
+            $this->productCollection->setCurPage($page++)->load();
+            /** @var Product $product */
+            foreach ($this->productCollection->getItems() as $product) {
+
+                if ($checkedProducts != 0 && $checkedProducts % 100 == 0) {
+                    $output->writeln("\nChecked $checkedProducts products...");
+                }
+
+                try {
+                    $status = $product->getStatus();
+                    if ($status == Status::STATUS_ENABLED and $payload = $this->productIntercept->getProductData($product, $storeId)) {
+                        $payload['integration_action'] = $this::EVENT_NAME;
+                        $payload['integration_action_id'] = $actionId;
+                        $sailClient->apiPost('content', $payload);
+                        $syncedProducts++;
+                    } else {
+                        $skippedProducts[] = $product;
+                    }
+
+                } catch (\Sailthru_Client_Exception $e) {
+                    $failedProducts[] = $product;
+                } catch (\Exception $e) {
+                    $output->writeln("Error on SKU {$product->getSku()}: {$e->getMessage()}");
+                } finally {
+                    $checkedProducts++;
+                }
+            }
+
+            $this->productCollection->clear();
+
+        } while ($page <= $this->productCollection->getLastPageNumber());
+
+        $endTime = microtime(true);
+        $time = $endTime - $startTime;
+
+        if ($skippedProducts) {
+            $productString = $this->printableProducts($skippedProducts);
+            $output->writeln("\n*****\nSkipped Products\n\n$productString\n*****");
+        }
+
+        if ($failedProducts) {
+            $productString = $this->printableProducts($failedProducts);
+            $output->writeln("\n*****\nFailed Products\n\n$productString\n*****");
+        }
+
+        $output->writeln("\n\n******\nResults\n\nSynced: {$syncedProducts} products\nTime: {$time} seconds\n*****");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName("sailthru:import:products");
+        $this->setDescription("Starts Product Catalog import into Sailthru for a given store");
+        $this->setDefinition([
+            new InputArgument(self::STORE_ARGUMENT, InputArgument::REQUIRED, "ID of store to sync"),
+        ]);
+        parent::configure();
+    }
+
+    /**
+     * @param Product[] $products
+     *
+     * @return string
+     */
+    private function printableProducts($products)
+    {
+        $ids = array_map( function(Product $product) {
+            return $product->getSku();
+        }, $products);
+
+        return implode(",", $ids);
+    }
+}

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -13,6 +13,7 @@ use Magento\Store\Model\StoreManager;
 use Sailthru\MageSail\Logger;
 use Sailthru\MageSail\Model\Config\Template\Data as TemplateConfig;
 use Sailthru\MageSail\Model\Template as TemplateModel;
+use Zend\View\Helper\Url;
 
 class ProductData extends AbstractHelper
 {
@@ -316,7 +317,7 @@ class ProductData extends AbstractHelper
         $product->getProductUrl(false); // generates the URL key
         /** @var Store $store */
         $store = $this->storeManager->getStore($product->getStoreId());
-        return $store->getBaseUrl() . $product->getRequestPath();
+        return $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true) . $product->getRequestPath();
     }
 
     // Magento 2 getImage seems to add a strange slash, therefore this.
@@ -324,6 +325,6 @@ class ProductData extends AbstractHelper
     {
         /** @var Store $store */
         $store = $this->storeManager->getStore($product->getStoreId());
-        return $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $product->getImage();
+        return $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA, true) . 'catalog/product' . $product->getImage();
     }
 }

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -3,6 +3,8 @@
 namespace Sailthru\MageSail\Helper;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Block\Product\AbstractProduct;
+use Magento\Catalog\Block\Product\ImageBuilder;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProduct;
 use Magento\Framework\App\Helper\Context;
@@ -64,6 +66,8 @@ class ProductData extends AbstractHelper
     /** @var ProductRepositoryInterface */
     private $productRepo;
 
+    private $imageBuilder;
+
     public function __construct(
         Context $context,
         StoreManager $storeManager,
@@ -72,11 +76,13 @@ class ProductData extends AbstractHelper
         TemplateConfig $templateConfig,
         ObjectManagerInterface $objectManager,
         ConfigurableProduct $configurableProduct,
-        ProductRepositoryInterface $productRepo
+        ProductRepositoryInterface $productRepo,
+        ImageBuilder $imageBuilder
     ) {
         parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager);
         $this->configurableProduct = $configurableProduct;
         $this->productRepo = $productRepo;
+        $this->imageBuilder = $imageBuilder;
     }
 
     /**
@@ -326,5 +332,17 @@ class ProductData extends AbstractHelper
         /** @var Store $store */
         $store = $this->storeManager->getStore($product->getStoreId());
         return $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA, true) . 'catalog/product' . $product->getImage();
+    }
+
+    public function retrieveThumbnail($product)
+    {
+        $imageWidth = 200;
+        $imageHeight = 200;
+
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        /** @var Image $imageHelper */
+        $imageHelper  = $objectManager->get('\Magento\Catalog\Helper\Image');
+        $image_url = $imageHelper->init($product, 'product_page_image_small')->setImageFile($product->getFile())->resize($imageWidth, $imageHeight)->getUrl();
+        return $image_url;
     }
 }

--- a/Plugin/ProductIntercept.php
+++ b/Plugin/ProductIntercept.php
@@ -177,13 +177,20 @@ class ProductIntercept
         if ($isVariant && !$updateVariants) {
             return false;
         }
-        
+
+        if (!$isVariant && !$this->productHelper->canShow($product)) {
+            return false;
+        }
+
         $attributes = $this->sailthruProduct->getProductAttributeValues($product);
         $categories = $this->sailthruProduct->getCategories($product);
 
         try {
             $data = [
                 'url'   => $this->sailthruProduct->getProductUrl($product, $storeId),
+                'keys' => [
+                    'sku' => $product->getSku()
+                ],
                 'title' => htmlspecialchars($product->getName()),
                 'spider' => 0,
                 'price' => $price = ($product->getPrice() ? $product->getPrice() :
@@ -218,7 +225,6 @@ class ProductIntercept
                     'isAvailable'  => (int) $product->isAvailable(),
                     'isVirtual'  => (int) $product->isVirtual(),
                     'isInStock'  => (int) $product->isInStock(),
-                    'isVisible' => (int) $this->productHelper->canShow($product)
                 ] + $attributes,
             ];
 
@@ -236,7 +242,7 @@ class ProductIntercept
             // Add product images
             if ($image = $product->getImage()) {
                 $data['images']['thumb'] = [
-                    "url" => $this->imageHelper->init($product, 'product_listing_thumbnail')->getUrl()
+                    "url" => $this->imageHelper->init($product, 'sailthru_thumb')->getUrl()
                 ];
                 $data['images']['full'] = [
                     "url"=> $this->sailthruProduct->getBaseImageUrl($product)

--- a/Plugin/ProductIntercept.php
+++ b/Plugin/ProductIntercept.php
@@ -229,7 +229,7 @@ class ProductIntercept
                 }
             }
 
-            if ($inventory = $product->getStockData()["qty"]) {
+            if ($inventory = $product->getStockData()["qty"] or $inventory = intval($product->getQty())) {
                 $data['inventory'] = $inventory;
             }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="Import" xsi:type="object">Sailthru\MageSail\Console\Command\Import</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Newsletter\Model\Subscriber">
         <plugin name="MageSail_SubscriptionInterceptor" type="Sailthru\MageSail\Plugin\SubscribeIntercept" />
     </type>

--- a/etc/view.xml
+++ b/etc/view.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+ Copied from /vendor/magento/theme-frontend-luma/etc/view.xm to support proper thumbnails.
+ See Magento 2 GH Issue #6119 https://github.com/magento/magento2/issues/6119
+-->
+<view xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/view.xsd">
+    <media>
+        <images module="Magento_Catalog">
+            <image id="sailthru_thumb" type="thumbnail">
+                <width>75</width>
+                <height>75</height>
+            </image>
+        </images>
+    </media>
+    <exclude>
+        <item type="file">Lib::jquery/jquery.min.js</item>
+        <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
+        <item type="file">Lib::jquery/jquery.ba-hashchange.min.js</item>
+        <item type="file">Lib::jquery/jquery.details.js</item>
+        <item type="file">Lib::jquery/jquery.details.min.js</item>
+        <item type="file">Lib::jquery/jquery.hoverIntent.js</item>
+        <item type="file">Lib::jquery/colorpicker/js/colorpicker.js</item>
+        <item type="file">Lib::requirejs/require.js</item>
+        <item type="file">Lib::requirejs/text.js</item>
+        <item type="file">Lib::date-format-normalizer.js</item>
+        <item type="file">Lib::legacy-build.min.js</item>
+        <item type="file">Lib::mage/captcha.js</item>
+        <item type="file">Lib::mage/dropdown_old.js</item>
+        <item type="file">Lib::mage/list.js</item>
+        <item type="file">Lib::mage/loader_old.js</item>
+        <item type="file">Lib::mage/webapi.js</item>
+        <item type="file">Lib::mage/zoom.js</item>
+        <item type="file">Lib::mage/translate-inline-vde.js</item>
+        <item type="file">Lib::mage/requirejs/mixins.js</item>
+        <item type="file">Lib::mage/requirejs/static.js</item>
+        <item type="file">Magento_Customer::js/zxcvbn.js</item>
+        <item type="file">Magento_Catalog::js/zoom.js</item>
+        <item type="file">Magento_Ui::js/lib/step-wizard.js</item>
+        <item type="file">Magento_Ui::js/form/element/ui-select.js</item>
+        <item type="file">Magento_Ui::js/form/element/file-uploader.js</item>
+        <item type="file">Magento_Ui::js/form/components/insert.js</item>
+        <item type="file">Magento_Ui::js/form/components/insert-listing.js</item>
+        <item type="directory">Magento_Ui::js/timeline</item>
+        <item type="directory">Magento_Ui::js/grid</item>
+        <item type="directory">Magento_Ui::js/dynamic-rows</item>
+        <item type="directory">Magento_Ui::templates/timeline</item>
+        <item type="directory">Magento_Ui::templates/grid</item>
+        <item type="directory">Magento_Ui::templates/dynamic-rows</item>
+        <item type="directory">Magento_Swagger::swagger-ui</item>
+        <item type="directory">Lib::modernizr</item>
+        <item type="directory">Lib::tiny_mce</item>
+        <item type="directory">Lib::varien</item>
+        <item type="directory">Lib::jquery/editableMultiselect</item>
+        <item type="directory">Lib::jquery/jstree</item>
+        <item type="directory">Lib::jquery/fileUploader</item>
+        <item type="directory">Lib::css</item>
+        <item type="directory">Lib::lib</item>
+        <item type="directory">Lib::extjs</item>
+        <item type="directory">Lib::prototype</item>
+        <item type="directory">Lib::scriptaculous</item>
+        <item type="directory">Lib::less</item>
+        <item type="directory">Lib::mage/adminhtml</item>
+        <item type="directory">Lib::mage/backend</item>
+    </exclude>
+</view>


### PR DESCRIPTION
* Adds `bin/magento` command-line functionality for importing products to Sailthru
* Hides non-individually-sellable products (e.g. bundle components) from Content API
* Creates new Sailthru thumb 
* Uses canonical HTTPS urls for products