### PR TITLE
Get rid of bad quotes in var names for Send API

### DIFF
--- a/Mail/Filter.php
+++ b/Mail/Filter.php
@@ -105,7 +105,8 @@ class Filter extends \Magento\Email\Model\Template\Filter
         if ($this->templateDirectives) {
             foreach ($this->templateDirectives as $key => $value) {
                 if (strstr($directive, $value)) {
-                    $this->templateVariables[$key] = $this->getVariable($directive, '');
+                    $formattedKey = str_replace('"', "", $key);
+                    $this->templateVariables[$formattedKey] = $this->getVariable($directive, '');
                 }
             }
         }


### PR DESCRIPTION
This resolves an issue with the Send API that sent some Magento vars with badly escaped quotes in var names. Specifically found with `password_reset_url` for password reset emails.