### PR TITLE
Use === for explicit check against strpos

### DIFF
--- a/Mail/Template.php
+++ b/Mail/Template.php
@@ -136,7 +136,7 @@ class Template extends \Magento\Email\Model\Template
         /**
          * trim copyright message
          */
-        if (preg_match('/^<!--[\w\W]+?-->/m', $templateText, $matches) && strpos($matches[0], 'Copyright') > 0) {
+        if (preg_match('/^<!--[\w\W]+?-->/m', $templateText, $matches) && !(strpos($matches[0], 'Copyright') === false)) {
             $templateText = str_replace($matches[0], '', $templateText);
         }
 


### PR DESCRIPTION
This fixes a small check that strips copyright info from Magento templates that Magento asked us to fix for marketplace approval.