### PR TITLE
Add order_id based scope resolve for admin sales module

### DIFF
--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -67,15 +67,5 @@ class AbstractHelper extends MageAbstractHelper
 
         return null;
     }
-
-    private function getStoreCodeFromOrderId($orderId) {
-        /** @var CollectionFactoryInterface $orderFactory */
-        $orderFactory = $this->objectManager->create('\Magento\Sales\Model\ResourceModel\Order\CollectionFactoryInterface');
-        $order = $orderFactory->create()
-                              ->addAttributeToSelect("store_id")
-                              ->addFilter("entity_id", $orderId)
-                              ->getFirstItem();
-        $storeId = $order->getStoreId();
-        return $this->storeManager->getStore($storeId)->getCode();
-    }
+    
 }

--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -48,7 +48,8 @@ class AbstractHelper extends MageAbstractHelper
     public function getSettingsVal($val, $storeId = null)
     {
         if ($storeId) {
-            return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore($storeId)->getCode());
+            $storeCode = $this->storeManager->getStore($storeId)->getCode();
+            return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $storeCode);
         }
         
         if ($storeCode = $this->_request->getParam('store')) {

--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -3,8 +3,6 @@
 namespace Sailthru\MageSail\Helper;
 
 use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Sales\Model\ResourceModel\Order\CollectionFactoryInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManager;
 use Magento\Framework\App\Helper\AbstractHelper as MageAbstractHelper;
@@ -13,7 +11,7 @@ use Sailthru\MageSail\Logger;
 use Sailthru\MageSail\Model\Template as TemplateModel;
 use Sailthru\MageSail\Model\Config\Template\Data as TemplateConfig;
 
-class AbstractHelper extends MageAbstractHelper
+abstract class AbstractHelper extends MageAbstractHelper
 {
     /** @var StoreManager  */
     protected $storeManager;

--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -55,15 +55,19 @@ abstract class AbstractHelper extends MageAbstractHelper
      */
     public function getSettingsVal($val)
     {
-        if ($storeId = $this->scopeResolver->resolveStoreId()) {
-            return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $storeId);
+        if ($storeId = $this->scopeResolver->resolveRequestedStoreId()) {
+            $storeCode = $this->storeManager->getStore($storeId)->getCode();
+            $this->_logger->info("Logging store $storeCode");
+            return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORE, $storeCode);
         }
 
         if ($websiteCode = $this->scopeResolver->resolveWebsiteId()) {
+            $storeId = $this->storeManager->getStore()->getId();
+            $this->_logger->info("Logging website $websiteCode with store $storeId");
             return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_WEBSITE, $websiteCode);
         }
 
-        return null;
+        return $this->scopeConfig->getValue($val);
     }
     
 }

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -92,6 +92,7 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
     protected $_apiSecret;
     private $moduleList;
     private $sailthruTemplates = [];
+    private $scopeResolver;
 
     /** @var \Magento\Framework\App\Request\Http */
     protected $request;
@@ -101,7 +102,8 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         Hid $hid,
         Logger $logger,
         StoreManager $storeManager,
-        ModuleListInterface $moduleList
+        ModuleListInterface $moduleList,
+        ScopeResolver $scopeResolver
     ) {
         parent::__construct($context);
         $this->hid = $hid;
@@ -110,6 +112,7 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         $this->logger = $logger;
         $this->storeManager = $storeManager;
         $this->moduleList = $moduleList;
+        $this->scopeResolver = $scopeResolver;
         $this->getClient();
     }
 
@@ -121,7 +124,8 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
                 $this->_apiSecret,
                 $this->logger,
                 $this->storeManager,
-                $this->moduleList
+                $this->moduleList,
+                $this->scopeResolver
             );
         } catch (\Sailthru_Client_Exception $e) {
             $this->client = $e->getMessage();

--- a/Helper/ClientManager.php
+++ b/Helper/ClientManager.php
@@ -36,19 +36,13 @@ class ClientManager extends AbstractHelper
         Context $context,
         StoreManager $storeManager,
         Logger $logger,
-        TemplateModel $templateModel,
-        TemplateConfig $templateConfig,
-        ObjectManagerInterface $objectManager,
-        ModuleListInterface $moduleList,
-        ScopeResolver $scopeResolver
+        ScopeResolver $scopeResolver,
+        ModuleListInterface $moduleList
     ) {
         parent::__construct(
             $context,
             $storeManager,
             $logger,
-            $templateModel,
-            $templateConfig,
-            $objectManager,
             $scopeResolver
         );
         $this->moduleList = $moduleList;
@@ -59,7 +53,7 @@ class ClientManager extends AbstractHelper
     {
         $apiKey = $this->getSettingsVal(self::XML_API_KEY, $storeId);
         $apiSecret = $this->getSettingsVal(self::XML_API_SECRET, $storeId);
-        $this->client = new MageClient($apiKey, $apiSecret, $this->logger, $this->storeManager, $this->moduleList);
+        $this->client = new MageClient($apiKey, $apiSecret, $this->logger, $this->storeManager, $this->moduleList, $this->scopeResolver);
     }
 
     public function getClient($update=false, $storeId = null)

--- a/Helper/ClientManager.php
+++ b/Helper/ClientManager.php
@@ -39,7 +39,8 @@ class ClientManager extends AbstractHelper
         TemplateModel $templateModel,
         TemplateConfig $templateConfig,
         ObjectManagerInterface $objectManager,
-        ModuleListInterface $moduleList
+        ModuleListInterface $moduleList,
+        ScopeResolver $scopeResolver
     ) {
         parent::__construct(
             $context,
@@ -47,7 +48,8 @@ class ClientManager extends AbstractHelper
             $logger,
             $templateModel,
             $templateConfig,
-            $objectManager
+            $objectManager,
+            $scopeResolver
         );
         $this->moduleList = $moduleList;
         $this->initClient();

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -72,15 +72,12 @@ class ProductData extends AbstractHelper
         Context $context,
         StoreManager $storeManager,
         Logger $logger,
-        TemplateModel $templateModel,
-        TemplateConfig $templateConfig,
-        ObjectManagerInterface $objectManager,
+        ScopeResolver $scopeResolver,
         ConfigurableProduct $configurableProduct,
         ProductRepositoryInterface $productRepo,
-        ImageBuilder $imageBuilder,
-        ScopeResolver $scopeResolver
+        ImageBuilder $imageBuilder
     ) {
-        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager, $scopeResolver);
+        parent::__construct($context, $storeManager, $logger, $scopeResolver);
         $this->configurableProduct = $configurableProduct;
         $this->productRepo = $productRepo;
         $this->imageBuilder = $imageBuilder;

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -77,9 +77,10 @@ class ProductData extends AbstractHelper
         ObjectManagerInterface $objectManager,
         ConfigurableProduct $configurableProduct,
         ProductRepositoryInterface $productRepo,
-        ImageBuilder $imageBuilder
+        ImageBuilder $imageBuilder,
+        ScopeResolver $scopeResolver
     ) {
-        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager);
+        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager, $scopeResolver);
         $this->configurableProduct = $configurableProduct;
         $this->productRepo = $productRepo;
         $this->imageBuilder = $imageBuilder;

--- a/Helper/ScopeResolver.php
+++ b/Helper/ScopeResolver.php
@@ -38,6 +38,7 @@ class ScopeResolver extends \Magento\Framework\App\Helper\AbstractHelper
         parent::__construct($context);
         $this->orderRepo = $orderRepo;
         $this->shipmentRepo = $shipmentRepo;
+        $this->storeManager = $storeManager;
         $this->webApiRequest = $webApiRequest;
     }
 
@@ -56,16 +57,17 @@ class ScopeResolver extends \Magento\Framework\App\Helper\AbstractHelper
      * Returns null if there's an issue.
      * @return int|null
      */
-    public function resolveStoreId()
+    public function resolveRequestedStoreId()
     {
         if ($storeId = $this->getStoreIdParam()) {
             return $storeId;
         }
-        if (!$this->getOrderId() && !$this->getShipmentId()) {
-            return $this->storeManager->getStore()->getId();
+
+        if ($this->getOrderId() || $this->getShipmentId()) {
+            return $this->getFromSalesScope();
         }
 
-        return $this->getFromSalesScope();
+        return null;
     }
 
     /**

--- a/Helper/ScopeResolver.php
+++ b/Helper/ScopeResolver.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Sailthru\MageSail\Helper;
+
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\ShipmentRepository;
+use Magento\Sales\Model\OrderRepository;
+use Magento\Framework\Webapi\Rest\Request as WebapiRequest;
+use Magento\Sales\Api\ShipmentRepositoryInterface;
+use Magento\Store\Model\StoreManager;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ScopeResolver extends \Magento\Framework\App\Helper\AbstractHelper
+{
+
+    /** @var OrderRepositoryInterface|OrderRepository */
+    protected $orderRepo;
+
+    /** @var ShipmentRepositoryInterface|ShipmentRepository  */
+    protected $shipmentRepo;
+
+    /** @var StoreManagerInterface|StoreManager */
+    protected $storeManager;
+
+    /** @var WebapiRequest  */
+    protected $webApiRequest;
+
+    public function __construct(
+        Context $context,
+        OrderRepositoryInterface $orderRepo,
+        ShipmentRepositoryInterface $shipmentRepo,
+        StoreManagerInterface $storeManager,
+        WebapiRequest $webApiRequest
+    ) {
+        parent::__construct($context);
+        $this->orderRepo = $orderRepo;
+        $this->shipmentRepo = $shipmentRepo;
+        $this->webApiRequest = $webApiRequest;
+    }
+
+    /**
+     * Attempts to resolve (simplistically) website scope
+     * Returns null if there's an issue.
+     */
+    public function resolveWebsiteId()
+    {
+        $websiteId = $this->_request->getParam('website') ?: $this->storeManager->getStore()->getWebsiteId();
+        return $websiteId ?: null;
+    }
+
+    /**
+     * Attempts to resolve store scope based on a few request params.
+     * Returns null if there's an issue.
+     * @return int|null
+     */
+    public function resolveStoreId()
+    {
+        if ($storeId = $this->getStoreIdParam()) {
+            return $storeId;
+        }
+        if (!$this->getOrderId() && !$this->getShipmentId()) {
+            return $this->storeManager->getStore()->getId();
+        }
+
+        return $this->getFromSalesScope();
+    }
+
+    /**
+     * Attempts to resolve store scope based on possible sales-related request params
+     * @return int|null
+     */
+    protected function getFromSalesScope()
+    {
+        $orderId = $this->getOrderId();
+        $shipmentId = $this->getShipmentId();
+        $entityId = $orderId ?: $shipmentId;
+        $repository = $orderId ? $this->orderRepo : $this->shipmentRepo;
+
+        try {
+            $entity = $repository->get($entityId);
+        } catch (\Exception $e) {
+            $this->_logger->error("Error resolving sales scope.", $e);
+            return null;
+        }
+
+        return $entity->getStoreId();
+    }
+
+    /**
+     * Try to retrieve order id from request parameters
+     * @return string|null
+     */
+    protected function getOrderId()
+    {
+        return $this->_request->getParam('order_id') ?: $this->webApiRequest->getParam('orderId');
+    }
+
+    /**
+     * Try to retrieve shipment id from request parameters
+     * @return string|null
+     */
+    protected function getShipmentId()
+    {
+        return $this->_request->getParam('shipment_id');
+    }
+
+    /**
+     * Try to retrieve store ID from request params
+     * @return string|null
+     */
+    protected function getStoreIdParam()
+    {
+        return $this->_request->getParam('store');
+    }
+
+}

--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -4,7 +4,13 @@ namespace Sailthru\MageSail\Helper;
 
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Store\Model\StoreManager;
 use Sailthru\MageSail\Cookie\Hid;
+use Sailthru\MageSail\Logger;
+use Sailthru\MageSail\Model\Config\Template\Data as TemplateConfig;
+use Sailthru\MageSail\Model\Template as TemplateModel;
+
 
 class Settings extends AbstractHelper
 {
@@ -13,6 +19,12 @@ class Settings extends AbstractHelper
     protected $_apiSecret;
     public $client;
     public $hid;
+
+    /** @var ObjectManagerInterface  */
+    protected $objectManager;
+
+    /** @var TemplateModel */
+    protected $templateModel;
 
     // Source models
     const SOURCE_MODEL_VALIDATION_MSG  = "Please Enter Valid Sailthru Credentials";
@@ -73,6 +85,20 @@ class Settings extends AbstractHelper
     /** Prefix for template name. */
     const MAGENTO_PREFIX = 'magento_';
 
+    public function __construct(
+        Context $context,
+        StoreManager $storeManager,
+        Logger $logger,
+        ScopeResolver $scopeResolver,
+        ObjectManagerInterface $objectManager,
+        TemplateModel $templateModel,
+        TemplateConfig $templateConfig
+    ) {
+        parent::__construct($context, $storeManager, $logger, $scopeResolver);
+        $this->objectManager = $objectManager;
+        $this->templateModel = $templateModel;
+        $this->templateConfig = $templateConfig;
+    }
 
     public function getInvalidMessage()
     {

--- a/MageClient.php
+++ b/MageClient.php
@@ -4,6 +4,7 @@ namespace Sailthru\MageSail;
 
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\Store\Model\StoreManager;
+use Sailthru\MageSail\Helper\ScopeResolver;
 
 class MageClient extends \Sailthru_Client
 {
@@ -19,10 +20,19 @@ class MageClient extends \Sailthru_Client
     /** @var ModuleListInterface */
     private $moduleList;
 
-    public function __construct($api_key, $secret, Logger $logger, StoreManager $storeManager, ModuleListInterface $moduleList)
-    {
+    /** @var ScopeResolver  */
+    private $scopeResolver;
+
+    public function __construct(
+        $api_key, $secret,
+        Logger $logger,
+        StoreManager $storeManager,
+        ModuleListInterface $moduleList,
+        ScopeResolver $scopeResolver
+    ) {
         $this->logger = $logger;
         $this->storeManager = $storeManager;
+        $this->scopeResolver = $scopeResolver;
         $this->moduleList = $moduleList;
         $options = [ "timeout" => 3000, "connection_timeout" => 3000];
         parent::__construct($api_key, $secret, false, $options);
@@ -32,7 +42,7 @@ class MageClient extends \Sailthru_Client
     protected function httpRequest($action, $data, $method = 'POST', $options = [])
     {
         $logAction = "{$method} /{$action}";
-        $storeId = intval($this->storeManager->getStore()->getId());
+        $storeId = $this->scopeResolver->resolveRequestedStoreId();
         $this->logger->info([
             'action'            => $logAction,
             'event_type'        => $this->_eventType,

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -26,9 +26,6 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
 
     /** @var Api */
     protected $apiHelper;
-
-    /** @var StoreManagerInterface */
-    protected $storeManager;
     
     /**
      * Transport constructor.
@@ -44,14 +41,12 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
         Settings $sailthruSettings,
         MessageInterface $message,
         Api $apiHelper,
-        StoreManagerInterface $storeManager,
         $parameters = null
     ) {
         $this->clientManager = $clientManager;
         $this->client = $clientManager;
         $this->sailthruSettings = $sailthruSettings;
         $this->apiHelper = $apiHelper;
-        $this->storeManager = $storeManager;
         parent::__construct($message, $parameters);
     }
 
@@ -91,22 +86,21 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
     public function sendViaAPI($templateData)
     {
         try {
-            $storeId = $this->storeManager->getStore()->getId();
-            $this->client = $this->client->getClient(true, $storeId);
+            $this->client = $this->client->getClient(true);
             $vars = [
                 "subj" => $this->_message->getSubject(),
                 "content" => $this->_message->getBody()->getRawContent(),
             ];
 
             # Get template name
-            $template = $this->sailthruSettings->getTemplateName($templateData['identifier'], $storeId);
+            $template = $this->sailthruSettings->getTemplateName($templateData['identifier']);
             # Vars used in Sailthru Magento 1 extension and template file.
             $vars += $this->sailthruSettings->getTemplateAdditionalVariables(
                 $template['orig_template_code'],
                 $templateData['variables']
             );
             # Create\Update template
-            $this->apiHelper->saveTemplate($template['name'], $this->sailthruSettings->getSender($storeId));
+            $this->apiHelper->saveTemplate($template['name'], $this->sailthruSettings->getSender());
 
             $message = [
                 "template" => $template['name'],

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -127,6 +127,10 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
             );
 
             $templateName = $template['name'];
+            if (!$this->apiHelper->templateExists($templateName)) {
+                $this->apiHelper->saveTemplate($templateName, $this->sailthruSettings->getSender($storeId));
+            }
+
             $message = [
                 "template" => $templateName,
                 "email" => $this->cleanEmails($this->recipients),

--- a/Mail/TransportBuilder.php
+++ b/Mail/TransportBuilder.php
@@ -4,6 +4,7 @@ namespace Sailthru\MageSail\Mail;
 
 use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\Mail\MessageInterface;
+use Magento\Store\Model\Store;
 
 class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
 {
@@ -22,11 +23,17 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
 
         $body = $template->processTemplate();
 
-        /** @customization START */
+            /** @customization START */
         $templateData = [
-            'variables' => $template->templateVariables ?? [],
+            'variables' => $template->templateVariables ?: [],
             'identifier' => $this->templateIdentifier,
         ];
+
+        if(isset($this->templateVars['store'])){
+            /** @var Store $store */
+            $store = $this->templateVars['store'];
+            $templateData['storeId'] = $store->getId();
+        }
 
         $this->message->setTemplateInfo($templateData);
         /** @customization END */

--- a/Observer/Frontend/CustomerLoggedIn.php
+++ b/Observer/Frontend/CustomerLoggedIn.php
@@ -2,42 +2,48 @@
 
 namespace Sailthru\MageSail\Observer\Frontend;
 
+use Magento\Customer\Model\Customer;
 use Sailthru\MageSail\Helper\ClientManager;
 use Sailthru\MageSail\Cookie\Hid as SailthruCookie;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Sailthru\MageSail\Logger;
 
 class CustomerLoggedIn implements ObserverInterface
 {
 
     private $sailthruCookie;
-    private $sailthruClient;
+    private $clientManager;
+    private $logger;
 
     public function __construct(
         ClientManager $clientManager,
-        SailthruCookie $sailthruCookie
+        SailthruCookie $sailthruCookie,
+        Logger $logger
     ) {
         $this->sailthruCookie = $sailthruCookie;
-        $this->sailthruClient = $clientManager;
+        $this->clientManager = $clientManager;
+        $this->logger = $logger;
     }
 
     public function execute(Observer $observer)
     {
+        /** @var Customer $customer */
         $customer = $observer->getData('customer');
-        $this->sailthruClient = $this->sailthruClient->getClient(true, $customer->getStore()->getId());
+        $this->logger->info("customer", $customer->debug());
+        $client = $this->clientManager->getClient(true, $customer->getStore()->getId());
         $sid = $customer->getData('sailthru_id');
-
+        $client->_eventType = 'CustomerLogin';
+        $data = [
+            'id' => $sid ? $sid : $customer->getEmail(),
+            'fields' => [
+                'keys' => 1,
+                'engagement' => 1,
+                'activity' => 1,
+            ]
+        ];
         try {
-            $this->sailthruClient->_eventType = 'CustomerLogin';
-            $data = [
-                    'id' => $sid ? $sid : $customer->getEmail(),
-                    'fields' => [
-                        'keys' => 1,
-                        'engagement' => 1,
-                        'activity' => 1,
-                    ]
-            ];
-            $response = $this->sailthruClient->apiPost('user', $data);
+            $response = $client->apiPost('user', $data);
             if (!$sid) {
                 $customerData = $customer->getDataModel();
                 $customerData->setCustomAttribute('sailthru_id', $response['keys']['sid']);
@@ -46,7 +52,7 @@ class CustomerLoggedIn implements ObserverInterface
             }
             $this->sailthruCookie->set($response["keys"]["cookie"]);
         } catch (\Exception $e) {
-            $this->sailthruClient->logger($e);
+            $this->logger->err("Exception logging in user with Sailthru: {$e->getMessage()}", ["exception" => $e]);
         }
     }
 }

--- a/Plugin/AddressIntercept.php
+++ b/Plugin/AddressIntercept.php
@@ -4,47 +4,53 @@ namespace Sailthru\MageSail\Plugin;
 
 use Magento\Customer\Model\Address;
 use Sailthru\MageSail\Helper\ClientManager;
+use Sailthru\MageSail\Helper\ScopeResolver;
 use Sailthru\MageSail\Helper\Settings as SailthruSettings;
 use Sailthru\MageSail\Helper\Customer as SailthruCustomer;
 
 class AddressIntercept
 {
+    private $sailthruSettings;
+    private $sailthruCustomer;
+    private $scopeResolver;
 
     public function __construct(
         ClientManager $clientManager,
         SailthruSettings $sailthruSettings,
-        SailthruCustomer $sailthruCustomer
+        SailthruCustomer $sailthruCustomer,
+        ScopeResolver $scopeResolver
     ) {
-        $this->client = $clientManager;
+        $this->clientManager = $clientManager;
         $this->sailthruSettings = $sailthruSettings;
         $this->sailthruCustomer = $sailthruCustomer;
+        $this->scopeResolver = $scopeResolver;
     }
 
     public function afterSave(Address $subject, Address $addressResult)
     {
-        $customerId = $addressResult->getCustomerId();
         $billing = $addressResult->getDataModel()->isDefaultBilling();
-        if ($billing) {
-            $customer = $addressResult->getCustomer();
-            $sid      = $customer->getData('sailthru_id');
-            $email    = $customer->getEmail();
-            $addressVars  = $this->sailthruCustomer->getAddressVars($addressResult);
-            $data = [
-                'id' => $sid ? $sid : $email,
-                'vars' => $addressVars,
-            ];
-            try {
-                $this->client = $this->client->getClient(true, $customer->getStore()->getId());
-                $this->client->_eventType = 'CustomerAddressUpdate';
-                $this->client->apiPost('user', $data);
-            } catch (\Sailthru_Client_Exception $e) {
-                $this->client->logger($e->getMessage());
-            } catch (\Exception $e) {
-                $this->client->logger($e->getMessage());
-            } finally {
-                return $addressResult;
-            }
-        } else {
+        if (!$billing) {
+            return $addressResult;
+        }
+
+        $storeId = $addressResult->getCustomer()->getStore()->getId();
+        $this->scopeResolver->emulateStore($storeId);
+        $customer = $addressResult->getCustomer();
+        $sid = $customer->getData('sailthru_id');
+        $email = $customer->getEmail();
+        $addressVars = $this->sailthruCustomer->getAddressVars($addressResult);
+        $data = [
+            'id' => $sid ? $sid : $email,
+            'vars' => $addressVars,
+        ];
+        try {
+            $client = $this->clientManager->getClient(true, $customer->getStore()->getId());
+            $client->_eventType = 'CustomerAddressUpdate';
+            $client->apiPost('user', $data);
+        } catch (\Exception $e) {
+            $this->clientManager->logger($e->getMessage());
+        } finally {
+            $this->scopeResolver->stopEmulation();
             return $addressResult;
         }
     }


### PR DESCRIPTION
This resolves a bug where emails sent via the admin sales module weren't properly retrieving the correctly scoped module settings. Previously, the scope was resolved by `store` or `website` request params or through `StoreManager`. We've now added a check for the `order_id ` request param which is exposed in the admin sales module and can look up store ID through that request.