### PR TITLE
Patch - Stop /template POST on send if template exists

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -12,6 +12,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManager;
 use Sailthru\MageSail\Cookie\Hid;
 use Sailthru\MageSail\Logger;
+use Sailthru\MageSail\MageClient;
 
 class Api extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -81,7 +82,9 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
         'sku'
     ];
 
+    /** @var  MageClient */
     public $client;
+
     public $hid;
     public $logger;
     public $storeManager;
@@ -372,20 +375,16 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
             ? array_column($templates['templates'], 'name')
             : [];
 
-            if (!in_array($templateIdentifier, $templates)) {
-                # Add template
-                $data = [
-                    "content_html" => "{content} {beacon}",
-                    "subject" => "{subj}",
-                    "from_email" => $sender,
-                    "is_link_tracking" => 1
-                ];
-            } else {
-                # Update template
-                $data = [
-                    "from_email" => $sender,
-                ];
+            if (in_array($templateIdentifier, $templates)) {
+                return;
             }
+
+            $data = [
+                "content_html" => "{content} {beacon}",
+                "subject" => "{subj}",
+                "from_email" => $sender,
+                "is_link_tracking" => 1
+            ];
 
             $response = $this->client->saveTemplate($templateIdentifier, $data);
 

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -362,7 +362,7 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * To create\update template in Sailthru.
+     * To create template in Sailthru.
      * 
      * @param  string $templateIdentifier
      * @param  string $sender
@@ -370,29 +370,27 @@ class Api extends \Magento\Framework\App\Helper\AbstractHelper
     public function saveTemplate($templateIdentifier, $sender)
     {
         try {
-            $templates = $this->getSailthruTemplates();
-            $templates = isset($templates['templates'])
-            ? array_column($templates['templates'], 'name')
-            : [];
-
-            if (in_array($templateIdentifier, $templates)) {
-                return;
-            }
-
             $data = [
                 "content_html" => "{content} {beacon}",
                 "subject" => "{subj}",
                 "from_email" => $sender,
                 "is_link_tracking" => 1
             ];
-
             $response = $this->client->saveTemplate($templateIdentifier, $data);
-
             if (isset($response['error']))
                 $this->client->logger($response['errormsg']);
         } catch (\Exception $e) {
             $this->client->logger($e->getMessage());
         }
+    }
+
+    public function templateExists($templateIdentifier) {
+        $templates = $this->getSailthruTemplates();
+        if (isset($templates['templates'])) {
+            $templates = array_column($templates['templates'], 'name');
+            return in_array($templateIdentifier, $templates);
+        }
+        return false;
     }
 
     private function getApiKey($storeId = null)

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -105,11 +105,14 @@ class Transport extends \Magento\Framework\Mail\Transport implements \Magento\Fr
                 $template['orig_template_code'],
                 $templateData['variables']
             );
-            # Create\Update template
-            $this->apiHelper->saveTemplate($template['name'], $this->sailthruSettings->getSender($storeId));
+
+            $templateName = $template['name'];
+            if (!$this->apiHelper->templateExists($templateName)) {
+                $this->apiHelper->saveTemplate($templateName, $this->sailthruSettings->getSender($storeId));
+            }
 
             $message = [
-                "template" => $template['name'],
+                "template" => $templateName,
                 "email" => $this->cleanEmails($this->recipients),
                 "vars" => $vars,
             ];

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -157,24 +157,25 @@
             <group id="transactionals" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Transactionals</label>
                 <field id="send_through_sailthru" type="select" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
-                    <label>Send all transactionals through Sailthru</label>
+                    <label>Send through Sailthru</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnableDisable</source_model>
-                    <tooltip>
-                        Allows you to send all Magento emails through Sailthru,
-                        and override templates for various Magento events.
-                    </tooltip>
                     <comment>
-                        NOTE: Will create generic Sailthru templates that will accept Magento
-                        templates for transactionals not specifically overriden.
+                        <![CDATA[
+                            Let Sailthru send all of your store's Magento transactional messaging.  Can use your Magento or Sailthru templates.
+                        ]]>
                     </comment>
                 </field>
                 <field id="from_sender" type="select" translate="label" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>From Email</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\VerifiedEmails</source_model>
                     <comment>
-                        All transactionals sent using Magento templates must be sent from a Sailthru-verified email.
+                        <![CDATA[
+                            When sending Magento templates, use this Sailthru-verified sender to deliver the email.<br/>
+                            <span style="font-size: 10px;">
+                                Add a new verified sender at <a style="font-size: 10px;" href="https://my.sailthru.com/verify">https://my.sailthru.com/verify</a>
+                            </span>
+                        ]]>
                     </comment>
-                    <tooltip>Don't see the right email? Add it at https://my.sailthru.com/verify</tooltip>
                     <depends>
                         <field id="*/*/send_through_sailthru">1</field>
                     </depends>


### PR DESCRIPTION
This addresses an issue causing delays during Magento transactional sends. 

* Removes /template POST force-updating sender before email sends
* Refactors validation around templates before send
* Cleans up Store Config language around sender