### PR TITLE
IN-1007 Comprehensive Scope Patch and Refactor [Testing In Progress]

### DIFF
--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -25,8 +25,11 @@ class AbstractHelper extends MageAbstractHelper
     /** @var TemplateConfig */
     protected $templateConfig;
 
-    /** @var ObjectManager */
+    /** @var ObjectManagerInterface */
     protected $objectManager;
+
+    /** @var ScopeResolver  */
+    protected $scopeResolver;
 
     public function __construct(
         Context $context,
@@ -34,7 +37,8 @@ class AbstractHelper extends MageAbstractHelper
         Logger $logger,
         TemplateModel $templateModel,
         TemplateConfig $templateConfig,
-        ObjectManagerInterface $objectManager
+        ObjectManagerInterface $objectManager,
+        ScopeResolver $scopeResolver
     ) {
         parent::__construct($context);
         $this->storeManager = $storeManager;
@@ -42,28 +46,20 @@ class AbstractHelper extends MageAbstractHelper
         $this->templateModel = $templateModel;
         $this->templateConfig = $templateConfig;
         $this->objectManager = $objectManager;
+        $this->scopeResolver = $scopeResolver;
     }
 
     public function getSettingsVal($val, $storeId = null)
     {
-        $scopeType = ScopeInterface::SCOPE_STORES;
-        $scopeCode = null;
-
         if ($storeId) {
-            $scopeCode = $this->storeManager->getStore($storeId)->getCode();
+            $storeCode = $this->storeManager->getStore($storeId)->getCode();
+            $this->logger->debug("passed Store ID $storeId");
+            return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORES, $storeCode);
+
         } else {
-            $storeCode = $this->_request->getParam('store');
-            $websiteCode = $this->_request->getParam('website');
-            if ($storeCode) {
-                $scopeType = ScopeInterface::SCOPE_STORE;
-                $scopeCode = $storeCode;
-            } elseif ($websiteCode) {
-                $scopeType = ScopeInterface::SCOPE_WEBSITE;
-                $scopeCode = $websiteCode;
-            } else {
-                $scopeCode = $this->storeManager->getStore()->getCode();
-            }
+            list($scopeCode, $scopeType) = $this->scopeResolver->getScope();
+            $this->logger->debug("resolved scope $scopeCode ($scopeType)");
+            return $this->scopeConfig->getValue($val, $scopeType, $scopeCode);
         }
-        return $this->scopeConfig->getValue($val, $scopeType, $scopeCode);
     }
 }

--- a/Helper/AbstractHelper.php
+++ b/Helper/AbstractHelper.php
@@ -53,12 +53,10 @@ class AbstractHelper extends MageAbstractHelper
     {
         if ($storeId) {
             $storeCode = $this->storeManager->getStore($storeId)->getCode();
-            $this->logger->debug("passed Store ID $storeId");
             return $this->scopeConfig->getValue($val, ScopeInterface::SCOPE_STORES, $storeCode);
 
         } else {
             list($scopeCode, $scopeType) = $this->scopeResolver->getScope();
-            $this->logger->debug("resolved scope $scopeCode ($scopeType)");
             return $this->scopeConfig->getValue($val, $scopeType, $scopeCode);
         }
     }

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -334,49 +334,6 @@ class Api extends AbstractHelper
         return $this->getAddressVars($address);
     }
 
-    /**
-     * To set Sailthru templates.
-     */
-    public function getSailthruTemplates()
-    {
-        if (empty($this->sailthruTemplates)) {
-            $this->sailthruTemplates = $this->client->getTemplates();
-        }
-
-        return $this->sailthruTemplates;
-    }
-
-    /**
-     * To create template in Sailthru.
-     * 
-     * @param  string $templateIdentifier
-     * @param  string $sender
-     */
-    public function saveTemplate($templateIdentifier, $sender)
-    {
-        try {
-            $data = [
-                "content_html" => "{content} {beacon}",
-                "subject" => "{subj}",
-                "from_email" => $sender,
-                "is_link_tracking" => 1
-            ];
-            $response = $this->client->saveTemplate($templateIdentifier, $data);
-            if (isset($response['error']))
-                $this->client->logger($response['errormsg']);
-        } catch (\Exception $e) {
-            $this->client->logger($e->getMessage());
-        }
-    }
-
-    public function templateExists($templateIdentifier) {
-        $templates = $this->getSailthruTemplates();
-        if (isset($templates['templates'])) {
-            $templates = array_column($templates['templates'], 'name');
-            return in_array($templateIdentifier, $templates);
-        }
-        return false;
-    }
 
     private function getApiKey($storeId = null)
     {

--- a/Helper/ClientManager.php
+++ b/Helper/ClientManager.php
@@ -52,7 +52,6 @@ class ClientManager extends AbstractHelper
             $scopeResolver
         );
         $this->moduleList = $moduleList;
-        $this->initClient();
     }
 
     public function initClient($storeId = null)
@@ -64,7 +63,7 @@ class ClientManager extends AbstractHelper
 
     public function getClient($update=false, $storeId = null)
     {
-        if ($update) {
+        if ($update or !$this->client) {
             $this->initClient($storeId);
         }
         return $this->client;

--- a/Helper/ClientManager.php
+++ b/Helper/ClientManager.php
@@ -39,7 +39,8 @@ class ClientManager extends AbstractHelper
         TemplateModel $templateModel,
         TemplateConfig $templateConfig,
         ObjectManagerInterface $objectManager,
-        ModuleListInterface $moduleList
+        ModuleListInterface $moduleList,
+        ScopeResolver $scopeResolver
     ) {
         parent::__construct(
             $context,
@@ -47,7 +48,8 @@ class ClientManager extends AbstractHelper
             $logger,
             $templateModel,
             $templateConfig,
-            $objectManager
+            $objectManager,
+            $scopeResolver
         );
         $this->moduleList = $moduleList;
         $this->initClient();
@@ -57,7 +59,7 @@ class ClientManager extends AbstractHelper
     {
         $apiKey = $this->getSettingsVal(self::XML_API_KEY, $storeId);
         $apiSecret = $this->getSettingsVal(self::XML_API_SECRET, $storeId);
-        $this->client = new MageClient($apiKey, $apiSecret, $this->logger, $this->storeManager, $this->moduleList);
+        $this->client = new MageClient($apiKey, $apiSecret, $this->getSetupVersion(), $this->logger, $this->scopeResolver);
     }
 
     public function getClient($update=false, $storeId = null)
@@ -109,6 +111,14 @@ class ClientManager extends AbstractHelper
     {
         $check = $this->apiValidate();
         return $check[0];
+    }
+
+    private function getSetupVersion()
+    {
+        $moduleData = $this->moduleList->getOne('Sailthru_MageSail');
+        return isset($moduleData['setup_version'])
+            ? $moduleData['setup_version']
+            : "";
     }
 
 }

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -167,12 +167,13 @@ class ProductData extends AbstractHelper
      */
     public function getTags(Product $product, $attributes = null, $categories = null)
     {
+        $storeId = $product->getStoreId();
         $tags = '';
-        if ($this->tagsUseKeywords()) {
+        if ($this->tagsUseKeywords($storeId)) {
             $keywords = htmlspecialchars($product->getData('meta_keyword'));
             $tags .= "$keywords,";
         }
-        if ($this->tagsUseCategories()) {
+        if ($this->tagsUseCategories($storeId)) {
             if ($categories === null) {
                 $categories = $this->getCategories($product);
             }
@@ -180,7 +181,7 @@ class ProductData extends AbstractHelper
         }
         try {
             $attribute_str = '';
-            if ($this->tagsUseAttributes()) {
+            if ($this->tagsUseAttributes($storeId)) {
                 if ($attributes === null) {
                     $attributes = $this->getProductAttributeValues($product);
                 }

--- a/Helper/ProductData.php
+++ b/Helper/ProductData.php
@@ -75,11 +75,12 @@ class ProductData extends AbstractHelper
         TemplateModel $templateModel,
         TemplateConfig $templateConfig,
         ObjectManagerInterface $objectManager,
+        ScopeResolver $scopeResolver,
         ConfigurableProduct $configurableProduct,
         ProductRepositoryInterface $productRepo,
         ImageBuilder $imageBuilder
     ) {
-        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager);
+        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager, $scopeResolver);
         $this->configurableProduct = $configurableProduct;
         $this->productRepo = $productRepo;
         $this->imageBuilder = $imageBuilder;

--- a/Helper/ScopeResolver.php
+++ b/Helper/ScopeResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Sailthru\MageSail\Helper;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\State;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Webapi\Rest\Request as WebapiRequest;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ScopeResolver extends AbstractHelper {
+
+    /** @var State  */
+    protected $appState;
+
+    /** @var WebapiRequest  */
+    protected $webapiRequest;
+
+    /** @var StoreManagerInterface  */
+    protected $storeManager;
+
+    private static $ADMIN_AREAS = [
+        Area::AREA_ADMINHTML,
+        Area::AREA_WEBAPI_REST,
+        Area::AREA_WEBAPI_SOAP
+    ];
+
+    public function __construct(
+        Context $context,
+        State $appState,
+        WebapiRequest $webapiRequest,
+        StoreManagerInterface $storeManager
+    ) {
+        parent::__construct($context);
+        $this->appState = $appState;
+        $this->webapiRequest = $webapiRequest;
+        $this->storeManager = $storeManager;
+    }
+
+    public function getScopeStore()
+    {
+        if ($this->isFrontendArea()){
+            return $this->storeManager->getStore()->getCode();
+        }
+
+        if ($storeId = $this->getRequestStoreScope()) {
+            return $this->storeManager->getStore($storeId);
+        }
+    }
+
+    /**
+     * Check if area code is an admin area code (including API calls)
+     * @return bool
+     */
+    protected function isAdminArea()
+    {
+            return in_array($this->getAreaCode(), self::$ADMIN_AREAS);
+    }
+
+    protected function isFrontendArea()
+    {
+        return $this->getAreaCode() === "frontend";
+    }
+
+    protected function getRequestStoreScope()
+    {
+        return $this->_request->getParam("store");
+    }
+
+    protected function getRequestWebsiteScope()
+    {
+        return $this->_request->getParam("website");
+    }
+
+    protected function getRequestOrderScope()
+    {
+        return $this->_request->getParam('order_id') ?: $this->webapiRequest->getParam('orderId');
+    }
+
+    private function getAreaCode()
+    {
+        try {
+            return $this->appState->getAreaCode();
+        } catch (LocalizedException $e) {
+            $this->_logger->error("Error getting area code: {$e->getMessage()}");
+            return false;
+        }
+    }
+
+}

--- a/Helper/ScopeResolver.php
+++ b/Helper/ScopeResolver.php
@@ -200,7 +200,8 @@ class ScopeResolver extends AbstractHelper {
      * @param null|int $websiteId
      * @return null|WebsiteInterface
      */
-    private function _getWebsite($websiteId = null) {
+    private function _getWebsite($websiteId = null)
+    {
         try {
             return $this->storeManager->getWebsite($websiteId);
         } catch (LocalizedException $e) {

--- a/Helper/Templates.php
+++ b/Helper/Templates.php
@@ -58,10 +58,11 @@ class Templates extends AbstractHelper {
     /**
      * To create template in Sailthru.
      *
-     * @param  string $templateIdentifier
-     * @param  string $sender
+     * @param   string $templateIdentifier
+     * @param   string $sender
+     * @param null|int $storeId
      */
-    public function saveTemplate($templateIdentifier, $sender, $storeId)
+    public function saveTemplate($templateIdentifier, $sender, $storeId = null)
     {
         $data = [
             "content_html" => "{content} {beacon}",

--- a/Helper/Templates.php
+++ b/Helper/Templates.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Sailthru\MageSail\Helper;
+
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Store\Model\StoreManager;
+use Sailthru\MageSail\Logger;
+use Sailthru\MageSail\Model\Config\Template\Data as TemplateConfig;
+use Sailthru\MageSail\Model\Template as TemplateModel;
+
+class Templates extends AbstractHelper {
+
+    /** @var array  */
+    private $templates = [];
+
+    /** @var ClientManager  */
+    private $clientManager;
+
+    public function __construct(
+        Context $context,
+        StoreManager $storeManager,
+        Logger $logger,
+        TemplateModel $templateModel,
+        TemplateConfig $templateConfig,
+        ObjectManagerInterface $objectManager,
+        ScopeResolver $scopeResolver,
+        ClientManager $clientManager
+    ) {
+        parent::__construct($context, $storeManager, $logger, $templateModel, $templateConfig, $objectManager, $scopeResolver);
+        $this->clientManager = $clientManager;
+    }
+
+    public function getSailthruTemplates($storeId = null)
+    {
+        if (empty($this->sailthruTemplates) or !isset($this->sailthruTemplates[$storeId])) {
+            $client = $this->clientManager->getClient(true, $storeId);
+            try {
+                $this->templates[$storeId] = $client->getTemplates();
+            } catch (\Sailthru_Client_Exception $ex) {
+                $this->logger->err("Exception getting templates: {$ex->getMessage()}");
+            }
+        }
+
+        return $this->templates[$storeId];
+    }
+
+    public function templateExists($templateIdentifier, $storeId = null)
+    {
+        $templates = $this->getSailthruTemplates($storeId);
+        if (isset($templates['templates'])) {
+            $templates = array_column($templates['templates'], 'name');
+            return in_array($templateIdentifier, $templates);
+        }
+        return false;
+    }
+
+    /**
+     * To create template in Sailthru.
+     *
+     * @param  string $templateIdentifier
+     * @param  string $sender
+     */
+    public function saveTemplate($templateIdentifier, $sender, $storeId)
+    {
+        $data = [
+            "content_html" => "{content} {beacon}",
+            "subject" => "{subj}",
+            "from_email" => $sender,
+            "is_link_tracking" => 1
+        ];
+
+        $client = $this->clientManager->getClient(true, $storeId);
+        try {
+            $response = $client->saveTemplate($templateIdentifier, $data);
+            if (isset($response['error']))
+                $client->logger($response['errormsg']);
+        } catch (\Exception $e) {
+            $client->logger($e->getMessage());
+        }
+    }
+
+
+}

--- a/MageClient.php
+++ b/MageClient.php
@@ -86,7 +86,7 @@ class MageClient extends \Sailthru_Client
     {
         $settings = $this->getSettings();
 
-        return $settings['from_emails'] ?? [];
+        return $settings['from_emails'] ?: [];
     }
 
     /**

--- a/Mail/Message.php
+++ b/Mail/Message.php
@@ -7,7 +7,7 @@ class Message extends \Magento\Framework\Mail\Message
     /**
      * Template info.
      *
-     * @var string
+     * @var array
      **/
     private $templateInfo = [];
 

--- a/Mail/TransportBuilder.php
+++ b/Mail/TransportBuilder.php
@@ -4,6 +4,7 @@ namespace Sailthru\MageSail\Mail;
 
 use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\Mail\MessageInterface;
+use Magento\Newsletter\Model\Subscriber;
 use Magento\Store\Api\Data\StoreInterface;
 
 class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
@@ -35,10 +36,18 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
             'identifier' => $this->templateIdentifier,
         ];
 
-        if(isset($this->templateVars['store'])){
+        if (isset($this->templateVars['store'])){
             /** @var StoreInterface $store */
             $store = $this->templateVars['store'];
             $templateData['storeId'] = $store->getId();
+        }
+
+        // Newsletter admin patch
+        if (isset($this->templateVars['subscriber'])) {
+            /** @var Subscriber $subscriber */
+            $subscriber = $this->templateVars['subscriber'];
+            $storeId = $subscriber->getStoreId();
+            $templateData['storeId'] = $storeId;
         }
 
         $this->message->setTemplateInfo($templateData);

--- a/Mail/TransportBuilder.php
+++ b/Mail/TransportBuilder.php
@@ -4,16 +4,23 @@ namespace Sailthru\MageSail\Mail;
 
 use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\Mail\MessageInterface;
+use Magento\Store\Api\Data\StoreInterface;
 
 class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
 {
+    /** @var Message */
+    protected $message;
+
     /**
      * Prepare message
      *
      * @return $this
+     * @throws \Magento\Framework\Exception\MailException
+     * @throws \Zend_Mail_Exception
      */
     protected function prepareMessage()
     {
+        /** @var Template $template */
         $template = $this->getTemplate();
         $types = [
             TemplateTypesInterface::TYPE_TEXT => MessageInterface::TYPE_TEXT,
@@ -24,9 +31,15 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
 
         /** @customization START */
         $templateData = [
-            'variables' => $template->templateVariables ?? [],
+            'variables' => $template->templateVariables ?: [],
             'identifier' => $this->templateIdentifier,
         ];
+
+        if(isset($this->templateVars['store'])){
+            /** @var StoreInterface $store */
+            $store = $this->templateVars['store'];
+            $templateData['storeId'] = $store->getId();
+        }
 
         $this->message->setTemplateInfo($templateData);
         /** @customization END */

--- a/Model/Config/Source/SailthruAbandonedCartTemplates.php
+++ b/Model/Config/Source/SailthruAbandonedCartTemplates.php
@@ -2,12 +2,24 @@
  
 namespace Sailthru\MageSail\Model\Config\Source;
 
+use Sailthru\MageSail\Helper\Api;
+use Sailthru\MageSail\Helper\Templates;
+
 class SailthruAbandonedCartTemplates extends AbstractSource
 {
+    /** @var Templates  */
+    private $sailthruTemplates;
+
+    public function __construct(Api $apiHelper, Templates $sailthruTemplates)
+    {
+        parent::__construct($apiHelper);
+        $this->sailthruTemplates = $sailthruTemplates;
+    }
+
     /** @inheritdoc */
     protected function getDisplayData()
     {
-        $data = $this->apiHelper->getSailthruTemplates();
+        $data = $this->sailthruTemplates->getSailthruTemplates();
         $tpl_options = [];
         
         if (!isset($data["templates"]))

--- a/Model/Config/Source/SailthruTemplates.php
+++ b/Model/Config/Source/SailthruTemplates.php
@@ -2,12 +2,23 @@
  
 namespace Sailthru\MageSail\Model\Config\Source;
 
+use Sailthru\MageSail\Helper\Api;
+use Sailthru\MageSail\Helper\Templates;
+
 class SailthruTemplates extends AbstractSource
 {
+    private $sailthruTemplates;
+
+    public function __construct(Api $apiHelper, Templates $sailthruTemplates)
+    {
+        parent::__construct($apiHelper);
+        $this->sailthruTemplates = $sailthruTemplates;
+    }
+
     /** @inheritdoc */
     protected function getDisplayData()
     {
-        $data = $this->apiHelper->getSailthruTemplates();
+        $data = $this->sailthruTemplates->getSailthruTemplates();
         $tpl_options = [
             ['value'=> 0, 'label'=>'Use current Magento template']
         ];

--- a/Observer/OrderSave.php
+++ b/Observer/OrderSave.php
@@ -92,10 +92,14 @@ class OrderSave implements ObserverInterface {
         $items = $order->getAllVisibleItems();
         $bundleIds = $this->getIdsOfType($items, "bundle");
         $configurableIds = $this->getIdsOfType($items, "configurable");
+        $storeId = $order->getStoreId();
 
         $data = [];
         foreach ($items as $item) {
             $product = $item->getProduct();
+            if ($product->getStoreId() != $storeId) {
+                $product->setStoreId($storeId);
+            }
             $_item = [];
             $_item['vars'] = [];
             if ($item->getProduct()->getTypeId() == 'configurable') {


### PR DESCRIPTION
The goal of this PR is to improve the stability of resolving scope in multi-store environments. This was tested on Magento 2.1.9. We will continue testing on 2.2.3 and 2.2.5. We are also open to community testing and feedback.

This PR:

* Creates a new Helper class `ScopeResolver `that will resolve and return the best scope it can find.
* Refactors the rest of the module to -when possible- retrieve Store ID from objects passed to functions rather than from global state, with a fallback to `ScopeResolver`.
* Logs API requests using ScopeResolver, bringing visibility to Sailthru data flow.
* Refactors `Api` legacy helper to extend from `AbstractHelper` and use `ClientManager`
* Creates a `Templates` helper extracted from `Api`
* Adds two patches to `Transport` and `TransportBuilder` to set store ID correctly during email sends for sales and newsletter modules based on magento/magento2#8117
* Adds a tool to the `MageClient` API client to truncate logged API responses, defaulting to GET /settings and GET /lists with the option to add or remove calls via extending the class.

### ScopResolver main functions

`getStore()`
1. If storefront, use Store Manager
2. If store ID is in request scope, return from that.
3. If there's a Sales-related ID, return that object's parent store (looks for sales and shipments)
4. return null

`getWebsite()`
1. If storefront, use Store Manager
2. If website ID is in request scope, return from that.
3. return null

`getScope()` returning a scope tuple
1. `[<store_scope_code>, SCOPE_STORE ]` if `getStore()` returns non-null.
2. `[<site_scope_code>, SCOPE_WEBSITE]` if `getWebsite()` returns non-null.
3. `[null, SCOPE_DEFAULT]` if it can't find a valid store or website (without this weird and hidden issues can emerge via the Store Configuration UI)

### Known Issue
`MageClient` is currently passed an instance of `ScopeResolver` and doesn't know when it was instantiated from a specific store, resulting in MageClient sometimes inaccurately logging that it's using default scope, when it is in fact scoped to the correct store. This will be addressed in a future commit or PR, where its constructor will be changed to support a ScopeResolver or some static data representing scope (array, string, data object, etc).