### PR TITLE
Add support for LO abandoned cart flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+*.idea/

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -8,6 +8,14 @@ use Sailthru\MageSail\Helper\ClientManager;
 class Check extends \Magento\Config\Block\System\Config\Form\Field
 {
 
+    const CHECK_TEMPLATE = 'system/loimage.phtml';
+
+    const LO_SUCCESS_MESSAGE = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+
+    const LO_ACTION_NEEDED_MESSAGE = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
+
+    const LO_IMG_URL = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
+
     /** @var ClientManager  */
     private $clientManager;
 
@@ -19,14 +27,6 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
         $this->clientManager = $clientManager;
         parent::__construct($context, $data);
     }
-
-    const CHECK_TEMPLATE = 'system/loimage.phtml';
-
-    const LO_SUCCESS_MESSAGE = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
-
-    const LO_ACTION_NEEDED_MESSAGE = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
-
-    const LO_IMG_URL = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
 
     protected function _prepareLayout()
     {

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -21,8 +21,11 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
     }
 
     const CHECK_TEMPLATE = 'system/loimage.phtml';
+
     const LO_SUCCESS_MESSAGE = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+
     const LO_ACTION_NEEDED_MESSAGE = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
+
     const LO_IMG_URL = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
 
     protected function _prepareLayout()

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -55,7 +55,7 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
         $usingJs = $this->clientManager->isJsEnabled();
         $data = array();
         if ($usingJs) {
-            $data['markup'] = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. Now you can create a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+            $data['markup'] = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
             $data['imgurl'] = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
         }
         else {

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Sailthru\MageSail\Block\System\Config\Image;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Sailthru\MageSail\Helper\ClientManager;
+
+class Check extends \Magento\Config\Block\System\Config\Form\Field
+{
+
+    /** @var ClientManager  */
+    private $clientManager;
+
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        ClientManager $clientManager,
+        array $data = []
+    ) {
+        $this->clientManager = $clientManager;
+        parent::__construct($context, $data);
+    }
+
+    const CHECK_TEMPLATE = 'system/loimage.phtml';
+
+    protected function _prepareLayout()
+    {
+        parent::_prepareLayout();
+        if (!$this->getTemplate()) {
+            $this->setTemplate(static::CHECK_TEMPLATE);
+        }
+        return $this;
+    }
+
+    /**
+     * Render image
+     *
+     * @param  \Magento\Framework\Data\Form\Element\AbstractElement $element
+     * @return string
+     */
+    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        // Remove scope label
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    /**
+     * Get the image url and label
+     *
+     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
+     * @return string
+     */
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        $usingJs = $this->clientManager->isJsEnabled();
+        $data = array();
+        if ($usingJs) {
+            $data['markup'] = '<strong>Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. Now you can create a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+            $data['imgurl'] = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
+        }
+        else {
+            $data['markup'] = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
+        }
+        $this->addData($data);
+        return $this->_toHtml();
+    }
+}

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -55,7 +55,7 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
         $usingJs = $this->clientManager->isJsEnabled();
         $data = array();
         if ($usingJs) {
-            $data['markup'] = '<strong>Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. Now you can create a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+            $data['markup'] = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. Now you can create a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
             $data['imgurl'] = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
         }
         else {

--- a/Block/System/Config/Image/Check.php
+++ b/Block/System/Config/Image/Check.php
@@ -21,6 +21,9 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
     }
 
     const CHECK_TEMPLATE = 'system/loimage.phtml';
+    const LO_SUCCESS_MESSAGE = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
+    const LO_ACTION_NEEDED_MESSAGE = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
+    const LO_IMG_URL = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
 
     protected function _prepareLayout()
     {
@@ -55,11 +58,11 @@ class Check extends \Magento\Config\Block\System\Config\Form\Field
         $usingJs = $this->clientManager->isJsEnabled();
         $data = array();
         if ($usingJs) {
-            $data['markup'] = '<strong style="color:#3fb220;">Great!</strong> With Sailthru Onsite and the Purchase API configured, you are all set on the Magento end. You must activate a Sailthru Lifecycle Optimizer flow with the Cart Abandonment entry to engage with your non-converting users. To learn more about creating a cart abandonment flow, visit our <a href="https://getstarted.sailthru.com/email/lo/automate-abandoned-cart-reminders/" target="_blank">docs</a>.';
-            $data['imgurl'] = 'https://getstarted.sailthru.com/wp-content/uploads/2017/08/Screen-Shot-2017-08-14-at-11.43.57-AM-1024x293.png';
+            $data['markup'] = self::LO_SUCCESS_MESSAGE;
+            $data['imgurl'] = self::LO_IMG_URL;
         }
         else {
-            $data['markup'] = '<strong style="color:#f49e42;">Action needed.</strong> You need to have the Sailthru JavaScript set up to use Lifecycle Optimizer for Abandoned Carts. Please go back to the setup tab and enter your Customer ID. Afterwards, you can return here to verify everything is working.';
+            $data['markup'] = self::LO_ACTION_NEEDED_MESSAGE;
         }
         $this->addData($data);
         return $this->_toHtml();

--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -130,7 +130,7 @@ class Settings extends AbstractHelper
 
     public function isAbandonedCartEnabled($storeId = null)
     {
-        return boolval($this->getSettingsVal(self::XML_ABANDONED_CART_ENABLED, $storeId));
+        return $this->getSettingsVal(self::XML_ABANDONED_CART_ENABLED, $storeId);
     }
 
     public function getAbandonedTemplate($storeId = null)

--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -42,6 +42,7 @@ class Settings extends AbstractHelper
     const XML_TRANSACTIONALS_SENDER    = "magesail_send/transactionals/from_sender";
     const XML_ORDER_ENABLED            = "magesail_send/transactionals/purchase_enabled";
     const XML_ORDER_TEMPLATE           = "magesail_send/transactionals/purchase_template";
+    const LO_ABANDONED_CART_ENABLED    = "1";
 
     /** Path to the `transactionals` tab. */
     const XML_TRANSACTIONALS_PATH = 'magesail_send/transactionals/';

--- a/Model/Config/Source/SailthruTemplates.php
+++ b/Model/Config/Source/SailthruTemplates.php
@@ -20,8 +20,8 @@ class SailthruTemplates extends AbstractSource
     {
         $data = $this->sailthruTemplates->getSailthruTemplates();
         $tpl_options = [
-            ['value'=> 0, 'label'=>'Use current Magento template'],
-            ['value'=> 'disableSailthru', 'label'=> 'Send with Magento (Do not use Sailthru)']
+            ['value'=> 0, 'label'=> 'Default Magento HTML via Sailthru (tracking)'],
+            ['value'=> 'disableSailthru', 'label'=> 'Default Magento HTML via Magento (no tracking)']
         ];
         
         if (!isset($data["templates"]))

--- a/Model/Config/Source/ValidatedLOEnableDisable.php
+++ b/Model/Config/Source/ValidatedLOEnableDisable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sailthru\MageSail\Model\Config\Source;
+
+class ValidatedLOEnableDisable extends AbstractSource
+{
+    protected function getDisplayData()
+    {
+        return [
+            ['value' => 2, 'label' => __('Use Reminder Template')],
+            ['value' => 1, 'label' => __('Use Lifecycle Optimizer (best practice)')],
+            ['value' => 0, 'label' => __('Disable')]
+        ];
+    }
+}

--- a/Plugin/CartIntercept.php
+++ b/Plugin/CartIntercept.php
@@ -45,32 +45,44 @@ class CartIntercept
     public function _gate(Cart $cart)
     {
         $storeId = $cart->getQuote()->getStoreId();
-        if ($this->sailthruSettings->isAbandonedCartEnabled($storeId)) {
+        if ($this->sailthruSettings->isAbandonedCartEnabled($storeId) == 2) {
             $this->client = $this->client->getClient(true, $storeId);
-            return $this->sendCart($cart);
+            return $this->sendCart($cart, false);
+        } else if ($this->sailthruSettings->isAbandonedCartEnabled($storeId) == 1) {
+            $this->client = $this->client->getClient(true, $storeId);
+            return $this->sendCart($cart, true);
         } else {
             return $cart;
         }
     }
-
-    public function sendCart(Cart $cart)
+    public function sendCart(Cart $cart, $isLOEnabled)
     {
         $customer = $cart->getCustomerSession()->getCustomer();
         $storeId = $cart->getQuote()->getStoreId();
         $email = $customer->getEmail();
+        $data = array();
         if ($email || $anonymousEmail = $this->isAnonymousReady($storeId)) {
             $email = $email ? $email : $anonymousEmail;
             try {
                 $this->client->_eventType = "CartUpdate";
                 $items = $this->_getItems($cart);
-                $data = [
-                    'email'             => $email,
-                    'items'             => $items,
-                    'incomplete'        => 1,
-                    'reminder_time'     => $this->sailthruSettings->getAbandonedTime($storeId),
-                    'reminder_template' => $this->sailthruSettings->getAbandonedTemplate($storeId),
-                    'message_id'        => $this->sailthruCookie->getBid(),
-                ];
+                if ($isLOEnabled) {
+                    $data = [
+                        'email'             => $email,
+                        'items'             => $items,
+                        'incomplete'        => 1,
+                        'message_id'        => $this->sailthruCookie->getBid(),
+                    ];    
+                } else {
+                    $data = [
+                        'email'             => $email,
+                        'items'             => $items,
+                        'incomplete'        => 1,
+                        'reminder_time'     => $this->sailthruSettings->getAbandonedTime($storeId),
+                        'reminder_template' => $this->sailthruSettings->getAbandonedTemplate($storeId),
+                        'message_id'        => $this->sailthruCookie->getBid(),
+                    ];
+                }
                 $this->client->apiPost("purchase", $data);
             } catch (\Sailthru_Client_Exception $e) {
                 $this->client->logger($e);

--- a/Plugin/CartIntercept.php
+++ b/Plugin/CartIntercept.php
@@ -56,14 +56,13 @@ class CartIntercept
             return $cart;
         }
     }
-    public function sendCart(Cart $cart)
+    public function sendCart(Cart $cart, $storeId)
     {
         $customer = $cart->getCustomerSession()->getCustomer();
-        $storeId = $cart->getQuote()->getStoreId();
         $email = $customer->getEmail();
         $this->client = $this->client->getClient(true, $storeId);
         if ($email || $anonymousEmail = $this->isAnonymousReady($storeId)) {
-        $items = $this->_getItems($cart);
+            $items = $this->_getItems($cart);
             $data = [
                 'email'             => $email,
                 'items'             => $items,

--- a/Plugin/GroupIntercept.php
+++ b/Plugin/GroupIntercept.php
@@ -25,7 +25,6 @@ class GroupIntercept
         'intercept',
         'tags',
         'lists',
-        'abandoned_cart',
         'transactionals',
     ];
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -156,19 +156,26 @@
         </section>
         <!-- Transactionals section -->
         <section id="magesail_send" translate="label" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Transactionals</label>
+            <label>Messaging</label>
             <tab>sailthru</tab>
             <resource>Sailthru_Magesail::config</resource>
             <group id="abandoned_cart" type="text" translate="label" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Sailthru Abandoned Cart</label>
                 <field id="enabled" type="select" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Abandoned Cart</label>
-                    <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnableDisable</source_model>
-                </field>                
+                    <label>Send Abandoned Cart Messages</label>
+                    <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedLOEnableDisable</source_model>
+                </field>   
+                <field id="lo_selected" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label/>
+                    <frontend_model>Sailthru\MageSail\Block\System\Config\Image\Check</frontend_model>
+                    <depends>
+                        <field id="*/*/enabled">1</field>
+                    </depends>
+                </field>
                 <field id="template" type="select" translate="label" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Abandoned Cart Template</label>
                     <depends>
-                        <field id="*/*/enabled">1</field>
+                        <field id="*/*/enabled">2</field>
                     </depends>
                     <source_model>Sailthru\MageSail\Model\Config\Source\SailthruAbandonedCartTemplates</source_model>
                 </field>
@@ -179,7 +186,7 @@
                         Amount of time after updating a non-empty cart that Sailthru should send the customer an email
                     </comment>
                     <depends>
-                        <field id="*/*/enabled">1</field>
+                        <field id="*/*/enabled">2</field>
                     </depends>
                 </field>
                 <field id="anonymous_carts" type="select" translate="label" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -201,7 +201,7 @@
             <group id="transactionals" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Transactionals</label>
                 <field id="send_through_sailthru" type="select" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
-                    <label>Send e-mails with Sailthru</label>
+                    <label>Send emails with Sailthru</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnableDisable</source_model>
                     <comment>
                         <![CDATA[

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -199,9 +199,9 @@
                 </field>
             </group>
             <group id="transactionals" type="text" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>General Transactionals</label>
+                <label>Transactionals</label>
                 <field id="send_through_sailthru" type="select" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="1">
-                    <label>Send through Sailthru</label>
+                    <label>Send e-mails with Sailthru</label>
                     <source_model>Sailthru\MageSail\Model\Config\Source\ValidatedEnableDisable</source_model>
                     <comment>
                         <![CDATA[

--- a/view/adminhtml/templates/system/loimage.phtml
+++ b/view/adminhtml/templates/system/loimage.phtml
@@ -2,11 +2,9 @@
     <p>
         <?php echo $block->getMarkup() ?>
     </p>
-    <?php
-        if ($block->getImgurl()) {
-            echo '<div style="text-align:center;">';
-            echo '<img src="' . $block->getImgurl() . '" style="width:75%;">';
-            echo '</div>';
-        }
-    ?>
+    <?php if ($block->getImgurl()): ?>
+        <div style="text-align:center;">
+            <img src="<?php echo $block->getImgurl() ?>" style="width:75%;">
+        </div>
+    <?php endif; ?>
 </div>

--- a/view/adminhtml/templates/system/loimage.phtml
+++ b/view/adminhtml/templates/system/loimage.phtml
@@ -4,7 +4,9 @@
     </p>
     <?php
         if ($block->getImgurl()) {
-            echo '<img src="' . $block->getImgurl() . '">';
+            echo '<div style="text-align:center;">';
+            echo '<img src="' . $block->getImgurl() . '" style="width:75%;">';
+            echo '</div>';
         }
     ?>
 </div>

--- a/view/adminhtml/templates/system/loimage.phtml
+++ b/view/adminhtml/templates/system/loimage.phtml
@@ -1,0 +1,10 @@
+<div class="<?php echo $block->getClass() ?>">
+    <p>
+        <?php echo $block->getMarkup() ?>
+    </p>
+    <?php
+        if ($block->getImgurl()) {
+            echo '<img src="' . $block->getImgurl() . '">';
+        }
+    ?>
+</div>


### PR DESCRIPTION
The plugin now gives Magento admins the ability to add users to abandoned cart flows via onsite JS. It will display more information about creating the flow if the admin enables the option and has onsite JS enabled, otherwise it will remind them to enabled onsite JS. The plugin then uses the purchase API as ingestion, at which point onsite takes over by writing to the relevant Kakfka topics which LO then consumes from. Also includes minor copy changes from https://sailthru.atlassian.net/browse/IN-1133.