### PR TITLE
[IN-1132]: Manage subscription status on login

### DIFF
--- a/Observer/Frontend/CustomerLoggedIn.php
+++ b/Observer/Frontend/CustomerLoggedIn.php
@@ -4,28 +4,38 @@ namespace Sailthru\MageSail\Observer\Frontend;
 
 use Sailthru\MageSail\Helper\ClientManager;
 use Sailthru\MageSail\Cookie\Hid as SailthruCookie;
+use Sailthru\MageSail\Helper\Settings as SailthruSettings;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Newsletter\Model\Subscriber;
 
 class CustomerLoggedIn implements ObserverInterface
 {
 
     private $sailthruCookie;
     private $sailthruClient;
+    private $sailthruSettings;
+    private $subscriber;
 
     public function __construct(
         ClientManager $clientManager,
-        SailthruCookie $sailthruCookie
+        SailthruCookie $sailthruCookie,
+        SailthruSettings $sailthruSettings,
+        Subscriber $subscriber
     ) {
         $this->sailthruCookie = $sailthruCookie;
         $this->sailthruClient = $clientManager;
+        $this->sailthruSettings = $sailthruSettings;
+        $this->subscriber = $subscriber;
     }
 
     public function execute(Observer $observer)
     {
         $customer = $observer->getData('customer');
-        $this->sailthruClient = $this->sailthruClient->getClient(true, $customer->getStore()->getId());
+        $storeId = $customer->getStore()->getId();
+        $this->sailthruClient = $this->sailthruClient->getClient(true, $storeId);
         $sid = $customer->getData('sailthru_id');
+        $newsletterList = $this->sailthruSettings->getNewsletterList($storeId);
 
         try {
             $this->sailthruClient->_eventType = 'CustomerLogin';
@@ -37,6 +47,11 @@ class CustomerLoggedIn implements ObserverInterface
                         'activity' => 1,
                     ]
             ];
+            $shouldUpdate = $this->shouldUpdate($sid);
+            if ($shouldUpdate) {
+                $this->subscriber->loadByEmail($customer->getEmail());
+                $this->subscriber->setSubscriberStatus(Subscriber::STATUS_UNSUBSCRIBED)->save();
+            }
             $response = $this->sailthruClient->apiPost('user', $data);
             if (!$sid) {
                 $customerData = $customer->getDataModel();
@@ -48,5 +63,10 @@ class CustomerLoggedIn implements ObserverInterface
         } catch (\Exception $e) {
             $this->sailthruClient->logger($e);
         }
+    }
+    private function shouldUpdate($sid)
+    {
+        $userData = $this->sailthruClient->apiGet('user', [ 'id' => $sid  ]);
+        return $userData['optout_email'] != 'none' || $this->subscriber->getStatus() == Subscriber::STATUS_UNSUBSCRIBED;
     }
 }


### PR DESCRIPTION
Previously, if a user opted out of e-mail communications via a hosted page, this would not reflect in a user's Magento account with regards to their newsletter subscription status. These changes mange this subscription status every time the user logs in.