### PR TITLE
SAIL-20 Fix transactional settings save issue

### DIFF
--- a/Observer/ConfigSave.php
+++ b/Observer/ConfigSave.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sailthru\MageSail\Observer;
+
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Sailthru\MageSail\Helper\Settings;
+use Sailthru\MageSail\Model\Config\Template\Data as TemplateConfig;
+
+class ConfigSave implements ObserverInterface
+{
+    protected $configWriter;
+    protected $request;
+    protected $templateConfig;
+
+    public function __construct(
+        WriterInterface $configWriter,
+        RequestInterface $request,
+        TemplateConfig $templateConfig
+    ) {
+        $this->configWriter = $configWriter;
+        $this->request = $request;
+        $this->templateConfig = $templateConfig;
+    }
+
+    /**
+     * Save transactional configs after saving config
+     *
+     * @param Observer $observer
+     *
+     * @return ConfigSave
+     */
+    public function execute(Observer $observer)
+    {
+        $groups = $this->request->getParam('groups');
+        if (empty($groups['transactionals'])) {
+            return $this;
+        }
+
+        $templates = $this->templateConfig->get('templates');
+        if (empty($templates)) {
+            return $this;
+        }
+
+        foreach ($templates as $template) {
+            $templateId = $template['id'];
+            if (!isset($groups['transactionals']['fields'][$templateId]['value'])) {
+                continue;
+            }
+
+            $this->configWriter->save(
+                Settings::XML_TRANSACTIONALS_PATH . $templateId,
+                $groups['transactionals']['fields'][$templateId]['value']
+            );
+        }
+
+        return $this;
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -9,4 +9,7 @@
     <event name="sales_order_place_after">
         <observer name="sailthru_order_confirmation" instance="Sailthru\MageSail\Observer\OrderSave"/>
     </event>
+    <event name="admin_system_config_changed_section_magesail_send">
+        <observer name="sailthru_config_save_magesail_send" instance="Sailthru\MageSail\Observer\ConfigSave"/>
+    </event>
 </config>


### PR DESCRIPTION
Issue: Transactionals emails config (Admin Panel -> Stores -> Configuration -> Sailthru -> Transactionals -> General Transactionals) not saving into database