### PR TITLE
Incorrect argument type

### DIFF
--- a/Mail/Transport/Sailthru.php
+++ b/Mail/Transport/Sailthru.php
@@ -130,7 +130,7 @@ class Sailthru extends \Magento\Framework\DataObject
                 throw new MailException(__($response['errormsg']));
             }
         } catch (\Exception $e) {
-            throw new MailException("Couldn't send the mail {$e->getMessage()}");
+            throw new MailException(__("Couldn't send the mail {$e->getMessage()}"));
         }
 
         return $this;


### PR DESCRIPTION
```
Exception: Argument 1 passed to Magento\Framework\Exception\LocalizedException::__construct() 
must be an instance of Magento\Framework\Phrase, string given, 
called in 
/vendor/sailthru/sailthru-magento2-extension/Mail/Transport/Sailthru.php on line 133
```