### PR TITLE
Fixed CHA-843: 502 error when invalid email provided during customer registration

### DIFF
--- a/Mail/Transport/Sailthru.php
+++ b/Mail/Transport/Sailthru.php
@@ -130,7 +130,7 @@ class Sailthru extends \Magento\Framework\DataObject
                 throw new MailException(__($response['errormsg']));
             }
         } catch (\Exception $e) {
-            throw new MailException("Couldn't send the mail {$e->getMessage()}");
+            throw new MailException(__("Couldn't send the mail {$e->getMessage()}"));
         }
 
         return $this;

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "magento/module-catalog": "^101.*",
     "magento/module-customer": "^100.1.*"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "magento/module-catalog": "^101.*",
     "magento/module-customer": "^100.1.*"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Sailthru_MageSail" setup_version="2.2.1" >
+    <module name="Sailthru_MageSail" setup_version="2.2.2" >
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Sailthru_MageSail" setup_version="2.2.0" >
+    <module name="Sailthru_MageSail" setup_version="2.2.1" >
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>


### PR DESCRIPTION
Issue was caused by improper argument type during exceptions catching if any Sailthru API error would happen.