### PR TITLE
Fixed "Zero Day" vulnerability in Magento - exploitation could lead to arbitrary code execution. CVE-2022-24086, APSB22-12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "magento/module-catalog": "^101.*",
     "magento/module-customer": "^100.1.*"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Sailthru_MageSail" setup_version="2.2.0" >
+    <module name="Sailthru_MageSail" setup_version="2.2.1" >
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>


### PR DESCRIPTION
Adobe has released security updates for Adobe Commerce and Magento Open Source. These updates resolve a vulnerability rated [critical](https://helpx.adobe.com/security/severity-ratings.html). Successful exploitation could lead to arbitrary code execution.

See: [Security updates available for Adobe Commerce APSB22-12](https://support.magento.com/hc/en-us/articles/4426353041293-Security-updates-available-for-Adobe-Commerce-APSB22-12-)