### PR TITLE
Definitions for php 8.2 support

### DIFF
--- a/Plugin/CartIntercept.php
+++ b/Plugin/CartIntercept.php
@@ -17,6 +17,17 @@ use Sailthru\MageSail\Cookie\Hid as SailthruCookie;
 
 class CartIntercept
 {
+    public ClientManager $clientManager;
+    public SailthruSettings $sailthruSettings;
+    public SailthruCookie $sailthruCookie;
+    public ProductRepositoryInterface $productRepo;
+    public Image $imageHelper;
+    public Config $mediaConfig;
+    public ProductHelper $productHelper;
+    public ConfigurableAttributeData $cpData;
+    public Configurable $cpModel;
+    public SwatchModel $swatchModel;
+
     public function __construct(
         ClientManager $clientManager,
         SailthruSettings $sailthruSettings,


### PR DESCRIPTION
Hi

I have added support for PHP 8.2.15 to the extension. 

Changes made:
- Added variable definitions to support PHP 8.2

I have tested these changes locally and they successfully address the compatibility issue.

Thanks
