### PR TITLE
[INT-628] udate magento dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
   "description": "Sailthru Module for Magento",
   "type":"magento2-module",
   "require": {
-    "php": "~5.6.0|~7.0.0|~7.1.3|~7.2.0|~7.3.0|~7.4.0|~8.0",
+    "php": "~5.6.0|~7.0.0|~7.1.3|~7.2.0|~7.3.0|~7.4.0|~8.0|~8.1",
     "sailthru/sailthru-php5-client": "1.2.3"
   },
   "suggest": {
-    "magento/module-newsletter": "^101.*",
-    "magento/module-catalog": "^101.*",
-    "magento/module-customer": "^100.1.*"
+    "magento/module-newsletter": "^100.3.*",
+    "magento/module-catalog": "^103.0.*",
+    "magento/module-customer": "^102.0.*"
   },
-  "version": "2.4.1",
+  "version": "2.4.2",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sailthru_MageSail" setup_version="2.4.1">
+    <module name="Sailthru_MageSail" setup_version="2.4.2">
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>


### PR DESCRIPTION
INT-628

Upgrade Magento modules and PHP version support:

- Upgrade "magento/module-newsletter" to "^100.3.*"
- Upgrade "magento/module-catalog" to "^103.0.*"
- Upgrade "magento/module-customer" to "^102.0.*"
- Update PHP version support to 8.1