### PR TITLE
Int 1636 magento compatibility issue

### DIFF
--- a/Mail/EmailMessage.php
+++ b/Mail/EmailMessage.php
@@ -50,7 +50,7 @@ class EmailMessage extends \Magento\Framework\Mail\EmailMessage
     {
         $body = $this->getBody();
 
-        if (empty($body)) {
+        if ($body === null) {
             return '';
         }
 
@@ -65,6 +65,6 @@ class EmailMessage extends \Magento\Framework\Mail\EmailMessage
             }
         }
 
-        return (string) $body;
+        return method_exists($body, '__toString') ? (string) $body : '';
     }
 }

--- a/Mail/EmailMessage.php
+++ b/Mail/EmailMessage.php
@@ -61,7 +61,7 @@ class EmailMessage extends \Magento\Framework\Mail\EmailMessage
         if (method_exists($body, 'getParts')) {
             $parts = $body->getParts();
             if (!empty($parts[0])) {
-                return $parts[0]->getRawContent() ?? '';
+                return $parts[0]->getBody() ?? '';
             }
         }
 

--- a/Mail/EmailMessage.php
+++ b/Mail/EmailMessage.php
@@ -65,6 +65,8 @@ class EmailMessage extends \Magento\Framework\Mail\EmailMessage
             }
         }
 
-        return method_exists($body, '__toString') ? (string) $body : '';
+        return is_scalar($body) || (is_object($body) && method_exists($body, '__toString'))
+            ? (string) $body
+            : '';
     }
 }

--- a/Mail/EmailMessage.php
+++ b/Mail/EmailMessage.php
@@ -42,12 +42,29 @@ class EmailMessage extends \Magento\Framework\Mail\EmailMessage
     /**
      * Get decoded MIME body text
      *
+     * Handles both Symfony MIME (Magento 2.4.8-p3+) and legacy multipart messages
+     *
      * @return string
      */
     public function getDecodedBodyText()
     {
-        return !empty($this->getBody()) && !empty($this->getBody()->getParts()[0])
-            ? $this->getBody()->getParts()[0]->getRawContent()
-            : '';
+        $body = $this->getBody();
+
+        if (empty($body)) {
+            return '';
+        }
+
+        if ($body instanceof \Symfony\Component\Mime\Part\TextPart) {
+            return $body->getBody();
+        }
+
+        if (method_exists($body, 'getParts')) {
+            $parts = $body->getParts();
+            if (!empty($parts[0])) {
+                return $parts[0]->getRawContent() ?? '';
+            }
+        }
+
+        return (string) $body;
     }
 }

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -82,11 +82,11 @@ class Transport extends \Magento\Email\Model\Transport
     /**
      * Send a mail using this transport
      *
-     * @return Transport
+     * @return void
      *
      * @throws \Magento\Framework\Exception\MailException
      */
-    public function sendMessage()
+    public function sendMessage(): void
     {
         try {
             $templateData = $this->getMessage()->getTemplateInfo();
@@ -107,7 +107,7 @@ class Transport extends \Magento\Email\Model\Transport
                         'store_id'      => $storeId,
                     ]);
 
-                    return $this;
+                    return;
                 }
                 /** @var Transport\Sailthru $transport */
                 $transport = $this->sailthruTransportFactory->create([
@@ -119,31 +119,82 @@ class Transport extends \Magento\Email\Model\Transport
                 ]);
                 $transport->sendMessage();
 
-                return $this;
+                return;
             }
 
             parent::sendMessage();
         } catch (\Exception $e) {
             throw new \Magento\Framework\Exception\MailException(new \Magento\Framework\Phrase($e->getMessage()), $e);
         }
-
-        return $this;
     }
 
     /**
      * Get data for email
+     *Symfony MIME handling (Magento 2.4.8-p3+)
      *
      * @return array
      */
     protected function getEmailData()
     {
-        $message = ZendMessage::fromString($this->getMessage()->getRawMessage());
+        if (class_exists('\Zend\Mail\Message')) {
+            $message = ZendMessage::fromString($this->getMessage()->getRawMessage());
+            return [
+                'to'      => $this->prepareRecipients($message),
+                'subject' => $this->prepareSubject($message),
+                'content' => $this->getMessage()->getDecodedBodyText()
+            ];
+        }
+
+        $emailMessage = $this->getMessage();
 
         return [
-            'to'      => $this->prepareRecipients($message),
-            'subject' => $this->prepareSubject($message),
-            'content' => $this->getMessage()->getDecodedBodyText()
+            'to'      => $this->extractRecipients($emailMessage),
+            'subject' => $this->extractSubject($emailMessage),
+            'content' => $emailMessage->getDecodedBodyText()
         ];
+    }
+
+    /**
+     * Extract recipients from Symfony email (Magento 2.4.8-p3+)
+     *
+     * @param EmailMessageInterface $message
+     * @return string
+     */
+    protected function extractRecipients(EmailMessageInterface $message)
+    {
+        $toAddresses = method_exists($message, 'getTo') ? $message->getTo() : [];
+
+        if (empty($toAddresses)) {
+            return '';
+        }
+
+        $emails = [];
+        foreach ($toAddresses as $address) {
+            if (is_object($address) && method_exists($address, 'getAddress')) {
+                $emails[] = $address->getAddress();
+            } elseif (is_object($address) && method_exists($address, 'getEmail')) {
+                $emails[] = $address->getEmail();
+            } elseif (is_string($address)) {
+                $emails[] = $address;
+            }
+        }
+
+        return implode(', ', $emails);
+    }
+
+    /**
+     * Extract subject from Symfony email (Magento 2.4.8-p3+)
+     *
+     * @param EmailMessageInterface $message
+     * @return string
+     */
+    protected function extractSubject(EmailMessageInterface $message)
+    {
+        if (method_exists($message, 'getSubject')) {
+            return (string) $message->getSubject();
+        }
+
+        return '';
     }
 
     /**

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -161,20 +161,24 @@ class Transport extends \Magento\Email\Model\Transport
      */
     protected function extractRecipients(EmailMessageInterface $message)
     {
-        $toAddresses = method_exists($message, 'getTo') ? $message->getTo() : [];
+        $toAddresses  = method_exists($message, 'getTo')  ? $message->getTo()  : [];
+        $ccAddresses  = method_exists($message, 'getCc')  ? $message->getCc()  : [];
+        $bccAddresses = method_exists($message, 'getBcc') ? $message->getBcc() : [];
+
+        if (empty($toAddresses) && empty($ccAddresses) && empty($bccAddresses)) {
+            throw new RuntimeException(
+                __('Email must contain at least one of "To", "Cc", or "Bcc" recipient')
+            );
+        }
 
         if (empty($toAddresses)) {
-            throw new RuntimeException(
-                __('Invalid email; contains no at least one of "To", "Cc", and "Bcc" header')
-            );
+            return '';
         }
 
         $emails = [];
         foreach ($toAddresses as $address) {
             if (is_object($address) && method_exists($address, 'getAddress')) {
                 $emails[] = $address->getAddress();
-            } elseif (is_object($address) && method_exists($address, 'getEmail')) {
-                $emails[] = $address->getEmail();
             } elseif (is_string($address)) {
                 $emails[] = $address;
             }
@@ -222,7 +226,7 @@ class Transport extends \Magento\Email\Model\Transport
         $hasTo = $headers->has('to');
         if (!$hasTo && !$headers->has('cc') && !$headers->has('bcc')) {
             throw new RuntimeException(
-                'Invalid email; contains no at least one of "To", "Cc", and "Bcc" header'
+                'Email must contain at least one of "To", "Cc", or "Bcc" recipient'
             );
         }
 

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -4,7 +4,6 @@ namespace Sailthru\MageSail\Mail;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\Exception\MailException;
 use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Mail\EmailMessageInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -167,7 +166,7 @@ class Transport extends \Magento\Email\Model\Transport
 
         if (empty($toAddresses) && empty($ccAddresses) && empty($bccAddresses)) {
             throw new RuntimeException(
-                __('Email must contain at least one of "To", "Cc", or "Bcc" recipient')
+                'Email must contain at least one of "To", "Cc", or "Bcc" recipient'
             );
         }
 
@@ -186,7 +185,7 @@ class Transport extends \Magento\Email\Model\Transport
 
         if (empty($emails)) {
             throw new RuntimeException(
-                __('Invalid "To" header; contains no addresses')
+                'Invalid "To" header; contains no addresses'
             );
         }
 

--- a/Mail/Transport.php
+++ b/Mail/Transport.php
@@ -13,9 +13,6 @@ use Sailthru\MageSail\Helper\Settings;
 use Sailthru\MageSail\Helper\Templates as SailthruTemplates;
 use Sailthru\MageSail\Mail\Transport\SailthruFactory as SailthruTransportFactory;
 use Sailthru\MageSail\Mail\Queue\EmailSendPublisher;
-use Zend\Mail\Message as ZendMessage;
-use Zend\Mail\Address\AddressInterface;
-use Zend\Mail\Header\HeaderInterface;
 
 class Transport extends \Magento\Email\Model\Transport
 {
@@ -130,14 +127,16 @@ class Transport extends \Magento\Email\Model\Transport
 
     /**
      * Get data for email
-     *Symfony MIME handling (Magento 2.4.8-p3+)
+     *
+     * Uses Zend Mail on Magento < 2.4.8 and the Symfony MIME API on 2.4.8-p3+.
+     * Zend FQCNs are used inline (not via `use`) to avoid autoload errors on 2.4.8-p3.
      *
      * @return array
      */
     protected function getEmailData()
     {
         if (class_exists('\Zend\Mail\Message')) {
-            $message = ZendMessage::fromString($this->getMessage()->getRawMessage());
+            $message = \Zend\Mail\Message::fromString($this->getMessage()->getRawMessage());
             return [
                 'to'      => $this->prepareRecipients($message),
                 'subject' => $this->prepareSubject($message),
@@ -165,7 +164,9 @@ class Transport extends \Magento\Email\Model\Transport
         $toAddresses = method_exists($message, 'getTo') ? $message->getTo() : [];
 
         if (empty($toAddresses)) {
-            return '';
+            throw new RuntimeException(
+                __('Invalid email; contains no at least one of "To", "Cc", and "Bcc" header')
+            );
         }
 
         $emails = [];
@@ -177,6 +178,12 @@ class Transport extends \Magento\Email\Model\Transport
             } elseif (is_string($address)) {
                 $emails[] = $address;
             }
+        }
+
+        if (empty($emails)) {
+            throw new RuntimeException(
+                __('Invalid "To" header; contains no addresses')
+            );
         }
 
         return implode(', ', $emails);
@@ -232,7 +239,7 @@ class Transport extends \Magento\Email\Model\Transport
 
         // If not on Windows, return normal string
         if (!$this->isWindowsOs() && version_compare($this->sailthruSettings->getMagentoVersion(), '2.3.3', '<')) {
-            return $to->getFieldValue(HeaderInterface::FORMAT_ENCODED);
+            return $to->getFieldValue(\Zend\Mail\Header\HeaderInterface::FORMAT_ENCODED);
         }
 
         // Otherwise, return list of emails
@@ -256,11 +263,11 @@ class Transport extends \Magento\Email\Model\Transport
     {
         $headers = $message->getHeaders();
         if (!$headers->has('subject')) {
-            return;
+            return '';
         }
         $header = $headers->get('subject');
 
-        return $header->getFieldValue(HeaderInterface::FORMAT_ENCODED);
+        return $header->getFieldValue(\Zend\Mail\Header\HeaderInterface::FORMAT_ENCODED);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "magento/module-catalog": "^101.*",
     "magento/module-customer": "^100.1.*"
   },
-  "version": "2.5.7",
+  "version": "2.5.8",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": { "Sailthru\\MageSail\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "type":"magento2-module",
   "require": {
     "php": "~5.6.0|~7.0.0|~7.1.3|~7.2.0|~7.3.0|~7.4.0|~8.0",
+    "magento/framework": "^102.0 || ^103.0",
     "sailthru/sailthru-php5-client": "1.2.4"
   },
   "suggest": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sailthru_MageSail" setup_version="2.5.7">
+    <module name="Sailthru_MageSail" setup_version="2.5.8">
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>


### PR DESCRIPTION
Magento 2.4.8-p3 replaced the Zend Mail library entirely with Symfony MIME, breaking transactional email sending for the extension. This PR adds backward-compatible support for both the Symfony MIME API (2.4.8-p3+) and the legacy Zend Mail API (older versions)